### PR TITLE
Update DID syntax for Ethereum Mainnet

### DIFF
--- a/src/controllers/did/DidController.ts
+++ b/src/controllers/did/DidController.ts
@@ -14,7 +14,7 @@ import {
 import axios from 'axios'
 import { injectable } from 'tsyringe'
 
-import { DidMethod, Network, Role } from '../../enums/enum'
+import { DidMethod, Network, NetworkTypes, Role } from '../../enums/enum'
 import ErrorHandlingService from '../../errorHandlingService'
 import { BadRequestError, InternalServerError } from '../../errors'
 import { CreateDidResponse, Did, DidRecordExample } from '../examples'
@@ -452,9 +452,9 @@ export class DidController extends Controller {
     }
 
     const createDidResponse = await this.agent.dids.create<EthereumDidCreateOptions>({
-      method: 'ethr',
+      method: DidMethod.Ethereum,
       options: {
-        network: networkName,
+        network: networkName === NetworkTypes.Mainnet ? '' : networkName,
         endpoint,
       },
       secret: {

--- a/src/controllers/multi-tenancy/MultiTenancyController.ts
+++ b/src/controllers/multi-tenancy/MultiTenancyController.ts
@@ -600,7 +600,7 @@ export class MultiTenancyController extends Controller {
       createDidResponse = await tenantAgent.dids.create<EthereumDidCreateOptions>({
         method: DidMethod.Ethereum,
         options: {
-          network: networkName,
+          network: networkName === NetworkTypes.Mainnet ? '' : networkName,
           endpoint,
         },
         secret: {


### PR DESCRIPTION
- Use empty string for the mainnet to remove mainnet string from the DID syntax for Ethereum.
- The Ethereum DID syntax would be did:ethr:<publicKey> instead of did:ethr:mainnet:<publicKey> 