### PR TITLE
hot-fix: add patch for the deprecated RPC URL of Polygon Mainnet

### DIFF
--- a/patches/@ayanworks+polygon-did-resolver+1.0.0+001+fix rpc url.patch
+++ b/patches/@ayanworks+polygon-did-resolver+1.0.0+001+fix rpc url.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@ayanworks/polygon-did-resolver/build/config.js b/node_modules/@ayanworks/polygon-did-resolver/build/config.js
+index 0ddbfa0..807688f 100644
+--- a/node_modules/@ayanworks/polygon-did-resolver/build/config.js
++++ b/node_modules/@ayanworks/polygon-did-resolver/build/config.js
+@@ -7,7 +7,7 @@ exports.networkConfig = {
+         CONTRACT_ADDRESS: '0xcB80F37eDD2bE3570c6C9D5B0888614E04E1e49E',
+     },
+     mainnet: {
+-        URL: 'https://polygon-rpc.com',
++        URL: 'https://polygon.drpc.org',
+         CONTRACT_ADDRESS: '0x0C16958c4246271622201101C83B9F0Fc7180d15',
+     },
+ };


### PR DESCRIPTION
- Create a patch by updating the Polygon Mainnet RPC URL for  @Ayanworks/polygon-did-resolver library