### PR TITLE
feat: migrate w3c schema to ethereum

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@ayanworks/credo-polygon-w3c-module": "1.0.0",
-    "@bhutan-ndi/ethr-credo-module": "1.0.3-alpha-20251226092637",
+    "@bhutan-ndi/ethr-credo-module": "1.0.3",
     "@credo-ts/anoncreds": "0.5.3",
     "@credo-ts/askar": "0.5.3",
     "@credo-ts/core": "0.5.3",

--- a/src/controllers/ethereum/EthereumController.ts
+++ b/src/controllers/ethereum/EthereumController.ts
@@ -90,6 +90,60 @@ export class Ethereum extends Controller {
   }
 
   /**
+   * Migrate W3C based schema to ethereum
+   *
+   * @returns Schema JSON
+   */
+  @Post('migrate-schema')
+  public async migrateSchema(
+    @Body()
+    migrateSchemaRequest: {
+      did: string
+      schemaId: string
+    },
+    @Res() internalServerError: TsoaResponse<500, { message: string }>,
+    @Res() badRequestError: TsoaResponse<400, { reason: string }>
+  ): Promise<unknown> {
+    try {
+      const { did, schemaId } = migrateSchemaRequest
+      if (!did) {
+        return badRequestError(400, {
+          reason: `DID is required.`,
+        })
+      }
+
+      if (!schemaId) {
+        return badRequestError(400, {
+          reason: `Existing Schema Id is required.`,
+        })
+      }
+
+      const schemaResponse = await this.agent.modules.ethereum.createExistingSchema({
+        did,
+        schemaId,
+      })
+
+      const schemaServerConfig = fs.readFileSync('config.json', 'utf-8')
+      const configJson = JSON.parse(schemaServerConfig)
+      if (!configJson.schemaFileServerURL) {
+        throw new Error('Please provide valid schema file server URL')
+      }
+
+      if (!schemaResponse?.schemaId) {
+        throw new Error('Invalid schema response')
+      }
+      const schemaPayload: SchemaMetadata = {
+        schemaUrl: configJson.schemaFileServerURL + schemaResponse?.schemaId,
+        did: schemaResponse?.did,
+        schemaId: schemaResponse?.schemaId,
+      }
+      return schemaPayload
+    } catch (error) {
+      return internalServerError(500, { message: `something went wrong: ${error}` })
+    }
+  }
+
+  /**
    * Estimate transaction
    *
    * @returns Transaction Object

--- a/src/controllers/multi-tenancy/MultiTenancyController.ts
+++ b/src/controllers/multi-tenancy/MultiTenancyController.ts
@@ -71,6 +71,7 @@ import ErrorHandlingService from '../../errorHandlingService'
 import { ENDORSER_DID_NOT_PRESENT } from '../../errorMessages'
 import {
   BadRequestError,
+  ConflictError,
   InternalServerError,
   NotFoundError,
   PaymentRequiredError,
@@ -1164,6 +1165,61 @@ export class MultiTenancyController extends Controller {
       return schemaPayload
     } catch (error) {
       throw new InternalServerError(`something went wrong: ${error}`)
+    }
+  }
+
+  @Security('apiKey')
+  @Post('/ethereum-wc3/migrate-schema/:tenantId')
+  public async migrateEthereumW3CSchema(
+    @Body()
+    createSchemaRequest: {
+      did: string
+      schemaId: string
+    },
+    @Path('tenantId') tenantId: string,
+  ): Promise<SchemaMetadata> {
+    try {
+      const { did, schemaId } = createSchemaRequest
+      if (!did ) {
+        throw new BadRequestError('DID is required.')
+      }
+      if (!schemaId ) {
+        throw new BadRequestError('Existing Schema Id is required.')
+      }
+
+      const schemaResponse = await this.agent.modules.tenants.withTenantAgent({ tenantId }, async (tenantAgent) => {
+        return await tenantAgent.modules.ethereum.createExistingSchema({
+          did,
+          schemaId
+        })
+      })
+
+      if (!schemaResponse?.schemaId) {
+        throw new BadRequestError('Invalid schema response')
+      }
+      const response: SchemaMetadata = {
+        did: schemaResponse?.did,
+        schemaId: schemaResponse?.schemaId,
+        schemaTxnHash: schemaResponse?.schemaTxnHash
+      }
+
+      return response
+    } catch (error: any) {
+      if (error?.message?.includes('Schema already exists')) {
+        throw new ConflictError(error.message)
+      }
+    
+      if (error?.message?.includes('Insufficient funds')) {
+        throw new BadRequestError(error.message)
+      }
+    
+      if (error?.message?.includes('not found')) {
+        throw new NotFoundError(error.message)
+      }
+    
+      throw new InternalServerError(
+        error?.message || 'Unexpected error during schema migration'
+      )
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -521,10 +521,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bhutan-ndi/ethr-credo-module@1.0.3-alpha-20251226092637":
-  version "1.0.3-alpha-20251226092637"
-  resolved "https://registry.yarnpkg.com/@bhutan-ndi/ethr-credo-module/-/ethr-credo-module-1.0.3-alpha-20251226092637.tgz#82cb8bab9a9ad32fbf77a00bd09c098a5c855208"
-  integrity sha512-CQEkzTEwLdxQVcYxvzUdNVwjj3+WKo75LvyGu57mGb0R82J2naHVdIuWb1OthATgNRW5OuA2+IzaaHCBOzmrzg==
+"@bhutan-ndi/ethr-credo-module@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@bhutan-ndi/ethr-credo-module/-/ethr-credo-module-1.0.3.tgz#68446d4db54488f20228292e7cfd07eabad53d61"
+  integrity sha512-/COABV+ltk0Vab4VXwJoJulgeO61Y83S44kzl9zsFme++BulzPKA9pWi+YX17zuXtvwuLoR/W6PiyBTEMwlyDg==
   dependencies:
     "@credo-ts/askar" "0.5.3"
     "@credo-ts/core" "0.5.3"


### PR DESCRIPTION
**Feature: Migrate W3C Schema to Ethereum**

**What’s Added**
This PR introduces new endpoint to support migrating an existing W3C schema to an Ethereum-anchored schema:

- `POST /migrate-schema` — migrate a schema to Ethereum using DID and schemaId of dedicated agent.
- `POST /ethereum-wc3/migrate-schema/:tenantId` — tenant-specific endpoint to migrate a schema for tenant.

Both endpoints:
- Validate required inputs (did, schemaId)
- Use the agent’s ethereum.createExistingSchema module
- Return basic schema metadata on success

**Why**

These changes enable the migration of existing W3C schema definitions to an Ethereum-based format, preparing the agent layer to support Ethereum-anchored schemas across the platform.