### PR TITLE
Fix: session leak, unbounded limits, missing config passthrough

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -180,9 +180,9 @@ export async function runCliServer() {
         type: parsed['wallet-type'],
         config: {
           host: parsed['wallet-url'],
-          connectTimeout: parsed['wallet-connect-timeout'] || Number(process.env.CONNECT_TIMEOUT),
-          maxConnections: parsed['wallet-max-connections'] || Number(process.env.MAX_CONNECTIONS),
-          idleTimeout: parsed['wallet-idle-timeout'] || Number(process.env.IDLE_TIMEOUT),
+          connectTimeout: parsed['wallet-connect-timeout'] || Number(process.env.CONNECT_TIMEOUT) || 10000,
+          maxConnections: parsed['wallet-max-connections'] || Number(process.env.MAX_CONNECTIONS) || 25,
+          idleTimeout: parsed['wallet-idle-timeout'] || Number(process.env.IDLE_TIMEOUT) || 30000,
         },
         credentials: {
           account: parsed['wallet-account'],
@@ -209,6 +209,7 @@ export async function runCliServer() {
     rpcUrl: parsed.rpcUrl,
     fileServerUrl: parsed.fileServerUrl,
     fileServerToken: parsed.fileServerToken,
+    walletScheme: parsed['wallet-scheme'],
     apiKey: parsed['apiKey'],
     updateJwtSecret: parsed['updateJwtSecret'],
   } as AriesRestConfig)

--- a/src/cliAgent.ts
+++ b/src/cliAgent.ts
@@ -191,7 +191,7 @@ const getModules = (
         })
       : new W3cCredentialsModule(),
     cache: new CacheModule({
-      cache: new InMemoryLruCache({ limit: Number(process.env.INMEMORY_LRU_CACHE_LIMIT) || Infinity }),
+      cache: new InMemoryLruCache({ limit: Number(process.env.INMEMORY_LRU_CACHE_LIMIT) || 500 }),
     }),
 
     questionAnswer: new QuestionAnswerModule(),
@@ -235,8 +235,8 @@ const getWithTenantModules = (
   )
   return {
     tenants: new TenantsModule<typeof modules>({
-      sessionAcquireTimeout: Number(process.env.SESSION_ACQUIRE_TIMEOUT) || Infinity,
-      sessionLimit: Number(process.env.SESSION_LIMIT) || Infinity,
+      sessionAcquireTimeout: Number(process.env.SESSION_ACQUIRE_TIMEOUT) || 30000,
+      sessionLimit: Number(process.env.SESSION_LIMIT) || 100,
     }),
     ...modules,
   }

--- a/src/events/CredentialEvents.ts
+++ b/src/events/CredentialEvents.ts
@@ -18,13 +18,17 @@ export const credentialEvents = async (agent: Agent, config: ServerConfig) => {
       credentialData: null,
     }
 
-    if (record?.connectionId) {
-      const connectionRecord = await agent.connections.findById(record.connectionId!)
-      body.outOfBandId = connectionRecord?.outOfBandId
-    }
+    try {
+      if (record?.connectionId) {
+        const connectionRecord = await agent.connections.findById(record.connectionId!)
+        body.outOfBandId = connectionRecord?.outOfBandId
+      }
 
-    const data = await agent.credentials.getFormatData(record.id)
-    body.credentialData = data
+      const data = await agent.credentials.getFormatData(record.id)
+      body.credentialData = data
+    } catch (error) {
+      agent.config.logger.warn('Failed to enrich credential event data', { error })
+    }
 
     if (config.webhookUrl) {
       await sendWebhookEvent(config.webhookUrl + '/credentials', body, agent.config.logger)

--- a/src/events/ProofEvents.ts
+++ b/src/events/ProofEvents.ts
@@ -14,8 +14,12 @@ export const proofEvents = async (agent: Agent, config: ServerConfig) => {
       const tenantAgent = await agent.modules.tenants.getTenantAgent({
         tenantId: event.metadata.contextCorrelationId,
       })
-      const data = await tenantAgent.proofs.getFormatData(record.id)
-      body.proofData = data
+      try {
+        const data = await tenantAgent.proofs.getFormatData(record.id)
+        body.proofData = data
+      } finally {
+        await tenantAgent.endSession()
+      }
     }
 
     //Emit webhook for dedicated agent


### PR DESCRIPTION
**Issue**
The credo's RDS instance requires a some of the largest instances in cloud environments to run due to excessive CPU and RAM consumption. DB insights shows the top SQL queries are all Askar `SELECT ... ARRAY_AGG` queries on the shared `items/items_tags` tables, with massive DB load utilization.

**Root causes**
1. Tenant session leak in `ProofEvents`
**File:** [`ProofEvents.ts`](https://github.com/Bhutan-NDI/ngotag-agent-controller/blob/fix/optimisation/src/events/ProofEvents.ts)
Every proof state change event for a multi-tenant agent calls `getTenantAgent()` which acquires a database session (PostgreSQL connection + wallet profile lock), but never calls `endSession()`. These sessions accumulate indefinitely over the lifetime of the process. With continuous proof exchanges across tenants, this causes hundreds of orphaned database connections consuming DB memory.

2. Unbounded tenant session limits
**File:** [`cliAgent.ts`](https://github.com/Bhutan-NDI/ngotag-agent-controller/blob/fix/optimisation/src/cliAgent.ts)
`sessionLimit` and `sessionAcquireTimeout` both defaulted to Infinity. This means every concurrent tenant API request opens a simultaneous DB session with no backpressure; if 500 requests arrive at once, 500 sessions are opened against PostgreSQL.

3. No DB connection pool defaults
**File:** [ `cli.ts`](https://github.com/Bhutan-NDI/ngotag-agent-controller/blob/fix/optimisation/src/cli.ts)
`maxConnections`, `connectTimeout`, and `idleTimeout` resolved to `NaN` when neither CLI args nor environment variables were set (since `Number(undefined)` returns `NaN`). Askar was left to open connections without any pool ceiling.

4. Unbounded in-memory LRU cache
**File:** [`cliAgent.ts`](https://github.com/Bhutan-NDI/ngotag-agent-controller/blob/fix/optimisation/src/cliAgent.ts)
The `InMemoryLruCache` defaulted to `limit: Infinity`, meaning cached entries (resolved DIDs, schemas, credential definitions) were never evicted. This caused unbounded memory growth in the Node.js process and GC pressure.

5. `walletScheme` config never passed through 
**File:** [`cli.ts`](https://github.com/Bhutan-NDI/ngotag-agent-controller/blob/fix/optimisation/src/cli.ts)
The `wallet-scheme` CLI option was parsed but never included in the object passed to `runRestAgent()`. The `walletScheme` parameter always arrived as `undefined`, making the fallback `AskarMultiWalletDatabaseScheme.ProfilePerWallet` always activate regardless of what was configured.

6. Unguarded DB queries in CredentialEvents
**File:** [`CredentialEvents.ts`](https://github.com/Bhutan-NDI/ngotag-agent-controller/blob/fix/optimisation/src/events/CredentialEvents.ts)
`connections.findById()` and `credentials.getFormatData()` were called without error handling on every credential state change event. A failure in either query could crash the event handler and leave connections in an indeterminate state.

**Changes**
1. Fix session leak: [`ProofEvents.ts`](https://github.com/Bhutan-NDI/ngotag-agent-controller/blob/fix/optimisation/src/events/ProofEvents.ts)
- Wrapped `tenantAgent.proofs.getFormatData()` in `try/finally`
- Added await `tenantAgent.endSession()` in the `finally` block to ensure the DB session is always released

2. Set bounded defaults: [`cliAgent.ts`](https://github.com/Bhutan-NDI/ngotag-agent-controller/blob/fix/optimisation/src/cliAgent.ts)
- Changed `sessionLimit` from `Infinity` to 100 (configurable via `SESSION_LIMIT` env var)
- Changed `sessionAcquireTimeout` from `Infinity` to `30000ms` (configurable via `SESSION_ACQUIRE_TIMEOUT` env var)
- Changed `InMemoryLruCache` limit from `Infinity` to `500` (configurable via `INMEMORY_LRU_CACHE_LIMIT` env var)

3.  Set connection pool defaults and fix config passthrough: [`cli.ts`](https://github.com/Bhutan-NDI/ngotag-agent-controller/blob/fix/optimisation/src/cli.ts)
- Added fallback defaults: `maxConnections: 25`, `connectTimeout: 10000` ms, `idleTimeout: 30000` ms
- Added missing `walletScheme: parsed['wallet-scheme']` to the config object passed to `runRestAgent()`

4. Guard DB queries: [`CredentialEvents.ts`](https://github.com/Bhutan-NDI/ngotag-agent-controller/blob/fix/optimisation/src/events/CredentialEvents.ts)
- Wrapped `connections.findById()` and `credentials.getFormatData()` in `try/catch`
- On failure, logs a warning and still sends the webhook/websocket event with the data available (graceful degradation)

### RECOMMENDED values:
`SESSION_ACQUIRE_TIMEOUT=30000` (30s) - fail fast instead of hanging!
`SESSION_LIMIT=500`
`INMEMORY_LRU_CACHE_LIMIT=2000`  - Covers all tenants + schemas + DIDs with room

`windowMs=1000`
`maxRateLimit=800`

`CONNECT_TIMEOUT=10000`
`MAX_CONNECTIONS=100`
`IDLE_TIMEOUT=30000`
