### PR TITLE
refactor: streamline proof and credential data retrieval and webhook event emission

### DIFF
--- a/src/cliAgent.ts
+++ b/src/cliAgent.ts
@@ -258,8 +258,8 @@ const getWithTenantModules = (
   )
   return {
     tenants: new TenantsModule<typeof modules>({
-      sessionAcquireTimeout: Number(process.env.SESSION_ACQUIRE_TIMEOUT) || Infinity,
-      sessionLimit: Number(process.env.SESSION_LIMIT) || Infinity,
+      sessionAcquireTimeout: Number(process.env.SESSION_ACQUIRE_TIMEOUT) || 10000,
+      sessionLimit: Number(process.env.SESSION_LIMIT) || 10,
     }),
     ...modules,
   }

--- a/src/events/BasicMessageEvents.ts
+++ b/src/events/BasicMessageEvents.ts
@@ -13,7 +13,7 @@ export const basicMessageEvents = async (agent: Agent, config: ServerConfig) => 
 
     // Only send webhook if webhook url is configured
     if (config.webhookUrl) {
-      await sendWebhookEvent(config.webhookUrl + '/basic-messages', body, agent.config.logger)
+      sendWebhookEvent(config.webhookUrl + '/basic-messages', body, agent.config.logger)
     }
 
     if (config.socketServer) {

--- a/src/events/ConnectionEvents.ts
+++ b/src/events/ConnectionEvents.ts
@@ -13,7 +13,7 @@ export const connectionEvents = async (agent: Agent, config: ServerConfig) => {
 
     // Only send webhook if webhook url is configured
     if (config.webhookUrl) {
-      await sendWebhookEvent(config.webhookUrl + '/connections', body, agent.config.logger)
+      sendWebhookEvent(config.webhookUrl + '/connections', body, agent.config.logger)
     }
 
     if (config.socketServer) {

--- a/src/events/CredentialEvents.ts
+++ b/src/events/CredentialEvents.ts
@@ -19,25 +19,34 @@ export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>
     }
 
     if (record.state === CredentialState.Done) {
-      if (event.metadata.contextCorrelationId !== 'default') {
-        await agent.modules.tenants.withTenantAgent(
-          { tenantId: event.metadata.contextCorrelationId },
-          async (tenantAgent) => {
-            const [data, connectionRecord] = await Promise.all([
-              tenantAgent.credentials.getFormatData(record.id),
-              record.connectionId ? tenantAgent.connections.findById(record.connectionId) : Promise.resolve(null),
-            ])
-            body.credentialData = data
-            body.outOfBandId = connectionRecord?.outOfBandId ?? null
-          }
+      try {
+        if (event.metadata.contextCorrelationId !== 'default') {
+          await agent.modules.tenants.withTenantAgent(
+            { tenantId: event.metadata.contextCorrelationId },
+            async (tenantAgent) => {
+              const [data, connectionRecord] = await Promise.all([
+                tenantAgent.credentials.getFormatData(record.id),
+                record.connectionId ? tenantAgent.connections.findById(record.connectionId) : Promise.resolve(null),
+              ])
+              body.credentialData = data
+              body.outOfBandId = connectionRecord?.outOfBandId ?? null
+            }
+          )
+        } else {
+          const [data, connectionRecord] = await Promise.all([
+            agent.credentials.getFormatData(record.id),
+            record.connectionId ? agent.connections.findById(record.connectionId) : Promise.resolve(null),
+          ])
+          body.credentialData = data
+          body.outOfBandId = connectionRecord?.outOfBandId ?? null
+        }
+      } catch (error) {
+        agent.config.logger.error(
+          `Failed to get credential format data for record ${record.id}, continuing with base record`,
+          { cause: error }
         )
-      } else {
-        const [data, connectionRecord] = await Promise.all([
-          agent.credentials.getFormatData(record.id),
-          record.connectionId ? agent.connections.findById(record.connectionId) : Promise.resolve(null),
-        ])
-        body.credentialData = data
-        body.outOfBandId = connectionRecord?.outOfBandId ?? null
+        body.credentialData = null
+        body.outOfBandId = null
       }
     }
 

--- a/src/events/CredentialEvents.ts
+++ b/src/events/CredentialEvents.ts
@@ -2,7 +2,7 @@ import type { RestMultiTenantAgentModules } from '../cliAgent'
 import type { ServerConfig } from '../utils/ServerConfig'
 import type { Agent, CredentialStateChangedEvent } from '@credo-ts/core'
 
-import { CredentialEventTypes } from '@credo-ts/core'
+import { CredentialEventTypes, CredentialState } from '@credo-ts/core'
 
 import { sendWebSocketEvent } from './WebSocketEvents'
 import { sendWebhookEvent } from './WebhookEvent'
@@ -18,22 +18,29 @@ export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>
       credentialData: null,
     }
 
-    if (event.metadata.contextCorrelationId !== 'default' && record?.connectionId) {
-      await agent.modules.tenants.withTenantAgent(
-        { tenantId: event.metadata.contextCorrelationId },
-        async (tenantAgent) => {
-          const connectionRecord = await tenantAgent.connections.findById(record.connectionId!)
-          const data = await tenantAgent.credentials.getFormatData(record.id)
-          body.credentialData = data
-          body.outOfBandId = connectionRecord?.outOfBandId
-        }
-      )
+    if (record.state === CredentialState.Done) {
+      if (event.metadata.contextCorrelationId !== 'default') {
+        await agent.modules.tenants.withTenantAgent(
+          { tenantId: event.metadata.contextCorrelationId },
+          async (tenantAgent) => {
+            const [data, connectionRecord] = await Promise.all([
+              tenantAgent.credentials.getFormatData(record.id),
+              record.connectionId ? tenantAgent.connections.findById(record.connectionId) : Promise.resolve(null),
+            ])
+            body.credentialData = data
+            body.outOfBandId = connectionRecord?.outOfBandId ?? null
+          }
+        )
+      } else {
+        const [data, connectionRecord] = await Promise.all([
+          agent.credentials.getFormatData(record.id),
+          record.connectionId ? agent.connections.findById(record.connectionId) : Promise.resolve(null),
+        ])
+        body.credentialData = data
+        body.outOfBandId = connectionRecord?.outOfBandId ?? null
+      }
     }
 
-    if (event.metadata.contextCorrelationId === 'default') {
-      const data = await agent.credentials.getFormatData(record.id)
-      body.credentialData = data
-    }
     // Only send webhook if webhook url is configured
     if (config.webhookUrl) {
       sendWebhookEvent(config.webhookUrl + '/credentials', body, agent.config.logger)

--- a/src/events/CredentialEvents.ts
+++ b/src/events/CredentialEvents.ts
@@ -36,7 +36,7 @@ export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>
     }
     // Only send webhook if webhook url is configured
     if (config.webhookUrl) {
-      await sendWebhookEvent(config.webhookUrl + '/credentials', body, agent.config.logger)
+      sendWebhookEvent(config.webhookUrl + '/credentials', body, agent.config.logger)
     }
 
     if (config.socketServer) {

--- a/src/events/ProofEvents.ts
+++ b/src/events/ProofEvents.ts
@@ -16,24 +16,16 @@ export const proofEvents = async (agent: Agent, config: ServerConfig) => {
       })
       const data = await tenantAgent.proofs.getFormatData(record.id)
       body.proofData = data
-      console.log(`body:`,JSON.stringify(body,null,2));
     }
 
-    if (event.metadata.contextCorrelationId === 'default' && record.state === 'done')
-    {
-      const data = await agent.proofs.getFormatData(record.id);
-      body.proofData = data
-    }
-
-    //Emit webhook for dedicated agent
-    if (event.metadata.contextCorrelationId === 'default') {
+    if (event.metadata.contextCorrelationId === 'default' && record.state === 'done') {
       const data = await agent.proofs.getFormatData(record.id)
       body.proofData = data
     }
 
     // Only send webhook if webhook url is configured
     if (config.webhookUrl) {
-      await sendWebhookEvent(config.webhookUrl + '/proofs', body, agent.config.logger)
+      sendWebhookEvent(config.webhookUrl + '/proofs', body, agent.config.logger)
     }
 
     if (config.socketServer) {

--- a/src/events/ProofEvents.ts
+++ b/src/events/ProofEvents.ts
@@ -1,3 +1,4 @@
+import type { RestMultiTenantAgentModules } from '../cliAgent'
 import type { ServerConfig } from '../utils/ServerConfig'
 import type { Agent, ProofStateChangedEvent } from '@credo-ts/core'
 
@@ -6,16 +7,18 @@ import { ProofEventTypes } from '@credo-ts/core'
 import { sendWebSocketEvent } from './WebSocketEvents'
 import { sendWebhookEvent } from './WebhookEvent'
 
-export const proofEvents = async (agent: Agent, config: ServerConfig) => {
+export const proofEvents = async (agent: Agent<RestMultiTenantAgentModules>, config: ServerConfig) => {
   agent.events.on(ProofEventTypes.ProofStateChanged, async (event: ProofStateChangedEvent) => {
     const record = event.payload.proofRecord
     const body = { ...record.toJSON(), ...event.metadata } as { proofData?: any }
     if (event.metadata.contextCorrelationId !== 'default' && record.state === 'done') {
-      const tenantAgent = await agent.modules.tenants.getTenantAgent({
-        tenantId: event.metadata.contextCorrelationId,
-      })
-      const data = await tenantAgent.proofs.getFormatData(record.id)
-      body.proofData = data
+      await agent.modules.tenants.withTenantAgent(
+        { tenantId: event.metadata.contextCorrelationId },
+        async (tenantAgent) => {
+          const data = await tenantAgent.proofs.getFormatData(record.id)
+          body.proofData = data
+        }
+      )
     }
 
     if (event.metadata.contextCorrelationId === 'default' && record.state === 'done') {

--- a/src/events/ProofEvents.ts
+++ b/src/events/ProofEvents.ts
@@ -13,17 +13,25 @@ export const proofEvents = async (agent: Agent<RestMultiTenantAgentModules>, con
     const body = { ...record.toJSON(), ...event.metadata } as { proofData?: any }
 
     if (record.state === ProofState.Done) {
-      if (event.metadata.contextCorrelationId !== 'default') {
-        await agent.modules.tenants.withTenantAgent(
-          { tenantId: event.metadata.contextCorrelationId },
-          async (tenantAgent) => {
-            const data = await tenantAgent.proofs.getFormatData(record.id)
-            body.proofData = data
-          }
+      try {
+        if (event.metadata.contextCorrelationId !== 'default') {
+          await agent.modules.tenants.withTenantAgent(
+            { tenantId: event.metadata.contextCorrelationId },
+            async (tenantAgent) => {
+              const data = await tenantAgent.proofs.getFormatData(record.id)
+              body.proofData = data
+            }
+          )
+        } else {
+          const data = await agent.proofs.getFormatData(record.id)
+          body.proofData = data
+        }
+      } catch (error) {
+        agent.config.logger.error(
+          `Failed to get proof format data for record ${record.id}, continuing with base record`,
+          { cause: error }
         )
-      } else {
-        const data = await agent.proofs.getFormatData(record.id)
-        body.proofData = data
+        body.proofData = null
       }
     }
 

--- a/src/events/ProofEvents.ts
+++ b/src/events/ProofEvents.ts
@@ -2,7 +2,7 @@ import type { RestMultiTenantAgentModules } from '../cliAgent'
 import type { ServerConfig } from '../utils/ServerConfig'
 import type { Agent, ProofStateChangedEvent } from '@credo-ts/core'
 
-import { ProofEventTypes } from '@credo-ts/core'
+import { ProofEventTypes, ProofState } from '@credo-ts/core'
 
 import { sendWebSocketEvent } from './WebSocketEvents'
 import { sendWebhookEvent } from './WebhookEvent'
@@ -11,19 +11,20 @@ export const proofEvents = async (agent: Agent<RestMultiTenantAgentModules>, con
   agent.events.on(ProofEventTypes.ProofStateChanged, async (event: ProofStateChangedEvent) => {
     const record = event.payload.proofRecord
     const body = { ...record.toJSON(), ...event.metadata } as { proofData?: any }
-    if (event.metadata.contextCorrelationId !== 'default' && record.state === 'done') {
-      await agent.modules.tenants.withTenantAgent(
-        { tenantId: event.metadata.contextCorrelationId },
-        async (tenantAgent) => {
-          const data = await tenantAgent.proofs.getFormatData(record.id)
-          body.proofData = data
-        }
-      )
-    }
 
-    if (event.metadata.contextCorrelationId === 'default' && record.state === 'done') {
-      const data = await agent.proofs.getFormatData(record.id)
-      body.proofData = data
+    if (record.state === ProofState.Done) {
+      if (event.metadata.contextCorrelationId !== 'default') {
+        await agent.modules.tenants.withTenantAgent(
+          { tenantId: event.metadata.contextCorrelationId },
+          async (tenantAgent) => {
+            const data = await tenantAgent.proofs.getFormatData(record.id)
+            body.proofData = data
+          }
+        )
+      } else {
+        const data = await agent.proofs.getFormatData(record.id)
+        body.proofData = data
+      }
     }
 
     // Only send webhook if webhook url is configured

--- a/src/events/QuestionAnswerEvents.ts
+++ b/src/events/QuestionAnswerEvents.ts
@@ -16,7 +16,7 @@ export const questionAnswerEvents = async (agent: Agent, config: ServerConfig) =
 
       // Only send webhook if webhook url is configured
       if (config.webhookUrl) {
-        await sendWebhookEvent(config.webhookUrl + '/question-answer', body, agent.config.logger)
+        sendWebhookEvent(config.webhookUrl + '/question-answer', body, agent.config.logger)
       }
 
       if (config.socketServer) {

--- a/src/events/ReuseConnectionEvents.ts
+++ b/src/events/ReuseConnectionEvents.ts
@@ -19,7 +19,7 @@ export const reuseConnectionEvents = async (agent: Agent, config: ServerConfig) 
     // Only send webhook if webhook url is configured
     if (config.webhookUrl) {
       agent.config.logger.debug('sending webhook event ::::::::')
-      await sendWebhookEvent(config.webhookUrl + '/connections', body, agent.config.logger)
+      sendWebhookEvent(config.webhookUrl + '/connections', body, agent.config.logger)
     }
 
     if (config.socketServer) {


### PR DESCRIPTION
- Remove fetching proof data for every proof event of dedicated agent
- Set webhookEvent delivery to sync to avoid affecting other request in the pipeline incase of slow webhook endpoint