### PR TITLE
Fix: Speed up proof state handling by decoupling webhook delivery

### DIFF
--- a/src/events/ProofEvents.ts
+++ b/src/events/ProofEvents.ts
@@ -10,30 +10,16 @@ export const proofEvents = async (agent: Agent, config: ServerConfig) => {
   agent.events.on(ProofEventTypes.ProofStateChanged, async (event: ProofStateChangedEvent) => {
     const record = event.payload.proofRecord
     const body = { ...record.toJSON(), ...event.metadata } as { proofData?: any }
-    if (event.metadata.contextCorrelationId !== 'default' && record.state === 'done') {
-      const tenantAgent = await agent.modules.tenants.getTenantAgent({
-        tenantId: event.metadata.contextCorrelationId,
-      })
-      const data = await tenantAgent.proofs.getFormatData(record.id)
-      body.proofData = data
-      console.log(`body:`,JSON.stringify(body,null,2));
-    }
 
-    if (event.metadata.contextCorrelationId === 'default' && record.state === 'done')
-    {
-      const data = await agent.proofs.getFormatData(record.id);
-      body.proofData = data
-    }
-
-    //Emit webhook for dedicated agent
-    if (event.metadata.contextCorrelationId === 'default') {
-      const data = await agent.proofs.getFormatData(record.id)
-      body.proofData = data
-    }
-
-    // Only send webhook if webhook url is configured
-    if (config.webhookUrl) {
-      await sendWebhookEvent(config.webhookUrl + '/proofs', body, agent.config.logger)
+    if (record.state === 'done') {
+      if (event.metadata.contextCorrelationId !== 'default') {
+        const tenantAgent = await agent.modules.tenants.getTenantAgent({
+          tenantId: event.metadata.contextCorrelationId,
+        })
+        body.proofData = await tenantAgent.proofs.getFormatData(record.id)
+      } else {
+        body.proofData = await agent.proofs.getFormatData(record.id)
+      }
     }
 
     if (config.socketServer) {
@@ -45,6 +31,11 @@ export const proofEvents = async (agent: Agent, config: ServerConfig) => {
           proofRecord: body,
         },
       })
+    }
+
+    // Only send webhook if webhook url is configured. Do not block proof state handling on webhook delivery.
+    if (config.webhookUrl) {
+      void sendWebhookEvent(config.webhookUrl + '/proofs', body, agent.config.logger)
     }
   })
 }

--- a/src/events/WebhookEvent.ts
+++ b/src/events/WebhookEvent.ts
@@ -2,16 +2,28 @@ import type { Logger } from '@credo-ts/core'
 
 import fetch from 'node-fetch'
 
-export const sendWebhookEvent = async (webhookUrl: string, body: Record<string, unknown>, logger: Logger) => {
+export const sendWebhookEvent = async (
+  webhookUrl: string,
+  body: Record<string, unknown>,
+  logger: Logger,
+  timeoutMs = Number(process.env.WEBHOOK_TIMEOUT_MS) || 1000
+) => {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), timeoutMs)
+
   try {
     await fetch(webhookUrl, {
       method: 'POST',
       body: JSON.stringify(body),
       headers: { 'Content-Type': 'application/json' },
+      signal: controller.signal,
     })
-  } catch (error) {
+  } catch (error: any) {
     logger.error(`Error sending ${body.type} webhook event to ${webhookUrl}`, {
       cause: error,
+      aborted: error.name === 'AbortError',
     })
+  } finally {
+    clearTimeout(timeout)
   }
 }


### PR DESCRIPTION
## Summary
- Stop blocking proof state event handling on webhook delivery
- Add a bounded Webhook timeout with `WEBHOOK_TIMEOUT_MS`, defaulting to 1000ms
- Remove duplicate proof format data lookup for default proof events
- Keep websocket emission on the immediate proof-state path

## Why
Slow or unavailable webhook listeners were able to delay proof-state processing, making mobile proof sharing and NDI login feel stuck.