### PR TITLE
fix(instrumentation): replace outer_msg_id with jwe_fp and add session pool stats

### DIFF
--- a/src/cliAgent.ts
+++ b/src/cliAgent.ts
@@ -450,22 +450,21 @@ export async function runRestAgent(restConfig: AriesRestConfig) {
       transport.app.use((req: any, res: any, next: any) => {
         if (req.method === 'POST') {
           const raw: string = typeof req.body === 'string' ? req.body : ''
-          const { recipientKeyShort, outerMsgId } = raw
+          const { recipientKeyShort, jweFp } = raw
             ? tryExtractFromJwe(raw)
-            : { recipientKeyShort: '', outerMsgId: '' }
+            : { recipientKeyShort: '', jweFp: '' }
           const spanId = makeSpanId()
           emitStructured(LogLevel.info, {
             hop: 'controller.http.inbound.received',
             span_id: spanId,
-            outer_msg_id: outerMsgId,
+            jwe_fp: jweFp,
             recipient_key_short: recipientKeyShort,
             content_length: req.headers['content-length'] ? Number(req.headers['content-length']) : undefined,
-            notes: outerMsgId ? undefined : 'outer_msg_id not in JWE protected header — timing join only',
           })
           res.locals.__dbg_span = spanId
           res.locals.__dbg_start = monoNow()
-          // Thread outer_msg_id through Credo's async chain so event handlers can read it.
-          return requestContext.run({ outerMsgId }, () => next())
+          // Thread JWE fingerprint through Credo's async chain so event handlers can read it.
+          return requestContext.run({ jweFp }, () => next())
         }
         next()
       })

--- a/src/events/CredentialEvents.ts
+++ b/src/events/CredentialEvents.ts
@@ -16,13 +16,13 @@ export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>
     const record = event.payload.credentialRecord
     const tenantId = event.metadata.contextCorrelationId ?? 'default'
     const threadId = record.threadId ?? ''
-    const outerMsgId = requestContext.getStore()?.outerMsgId ?? ''
+    const jweFp = requestContext.getStore()?.jweFp ?? ''
 
     emitStructured(LogLevel.info, {
       hop: 'controller.event.credential.state',
       flow: 'issuance',
       thread_id: threadId,
-      outer_msg_id: outerMsgId,
+      jwe_fp: jweFp,
       tenant_id: tenantId,
       conn_id: record.connectionId ?? '',
       credential_state: record.state,
@@ -49,7 +49,7 @@ export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>
               hop: 'controller.handler.entry',
               flow: 'issuance',
               thread_id: threadId,
-              outer_msg_id: outerMsgId,
+              jwe_fp: jweFp,
               span_id: handlerSpanId,
               tenant_id: tenantId,
               conn_id: record.connectionId ?? '',
@@ -64,7 +64,7 @@ export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>
               hop: 'controller.handler.exit',
               flow: 'issuance',
               thread_id: threadId,
-              outer_msg_id: outerMsgId,
+              jwe_fp: jweFp,
               span_id: handlerSpanId,
               tenant_id: tenantId,
               conn_id: record.connectionId ?? '',
@@ -78,7 +78,7 @@ export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>
             hop: 'controller.handler.entry',
             flow: 'issuance',
             thread_id: threadId,
-            outer_msg_id: outerMsgId,
+            jwe_fp: jweFp,
             span_id: handlerSpanId,
             tenant_id: tenantId,
             conn_id: record.connectionId ?? '',
@@ -93,7 +93,7 @@ export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>
             hop: 'controller.handler.exit',
             flow: 'issuance',
             thread_id: threadId,
-            outer_msg_id: outerMsgId,
+            jwe_fp: jweFp,
             span_id: handlerSpanId,
             tenant_id: tenantId,
             conn_id: record.connectionId ?? '',
@@ -116,7 +116,7 @@ export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>
         hop: 'controller.handler.entry',
         flow: 'issuance',
         thread_id: threadId,
-        outer_msg_id: outerMsgId,
+        jwe_fp: jweFp,
         span_id: handlerSpanId,
         tenant_id: tenantId,
         conn_id: record.connectionId ?? '',
@@ -125,7 +125,7 @@ export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>
         hop: 'controller.handler.exit',
         flow: 'issuance',
         thread_id: threadId,
-        outer_msg_id: outerMsgId,
+        jwe_fp: jweFp,
         span_id: handlerSpanId,
         tenant_id: tenantId,
         conn_id: record.connectionId ?? '',

--- a/src/events/ProofEvents.ts
+++ b/src/events/ProofEvents.ts
@@ -22,13 +22,13 @@ export const proofEvents = async (agent: Agent<RestMultiTenantAgentModules>, con
       `[ProofEvent] Proof state changed event received - threadId=${threadId}, state=${state}, contextCorrelationId=${tenantId}`
     )
 
-    const outerMsgId = requestContext.getStore()?.outerMsgId ?? ''
+    const jweFp = requestContext.getStore()?.jweFp ?? ''
 
     emitStructured(LogLevel.info, {
       hop: 'controller.event.proof.state',
       flow: 'verification',
       thread_id: threadId ?? '',
-      outer_msg_id: outerMsgId,
+      jwe_fp: jweFp,
       tenant_id: tenantId,
       conn_id: record.connectionId ?? '',
       proof_state: state,
@@ -50,7 +50,7 @@ export const proofEvents = async (agent: Agent<RestMultiTenantAgentModules>, con
               hop: 'controller.handler.entry',
               flow: 'verification',
               thread_id: threadId ?? '',
-              outer_msg_id: outerMsgId,
+              jwe_fp: jweFp,
               span_id: handlerSpanId,
               tenant_id: tenantId,
               conn_id: record.connectionId ?? '',
@@ -64,7 +64,7 @@ export const proofEvents = async (agent: Agent<RestMultiTenantAgentModules>, con
               hop: 'controller.handler.exit',
               flow: 'verification',
               thread_id: threadId ?? '',
-              outer_msg_id: outerMsgId,
+              jwe_fp: jweFp,
               span_id: handlerSpanId,
               tenant_id: tenantId,
               conn_id: record.connectionId ?? '',
@@ -78,7 +78,7 @@ export const proofEvents = async (agent: Agent<RestMultiTenantAgentModules>, con
             hop: 'controller.handler.entry',
             flow: 'verification',
             thread_id: threadId ?? '',
-            outer_msg_id: outerMsgId,
+            jwe_fp: jweFp,
             span_id: handlerSpanId,
             tenant_id: tenantId,
             conn_id: record.connectionId ?? '',
@@ -92,7 +92,7 @@ export const proofEvents = async (agent: Agent<RestMultiTenantAgentModules>, con
             hop: 'controller.handler.exit',
             flow: 'verification',
             thread_id: threadId ?? '',
-            outer_msg_id: outerMsgId,
+            jwe_fp: jweFp,
             span_id: handlerSpanId,
             tenant_id: tenantId,
             conn_id: record.connectionId ?? '',
@@ -114,7 +114,7 @@ export const proofEvents = async (agent: Agent<RestMultiTenantAgentModules>, con
         hop: 'controller.handler.entry',
         flow: 'verification',
         thread_id: threadId ?? '',
-        outer_msg_id: outerMsgId,
+        jwe_fp: jweFp,
         span_id: handlerSpanId,
         tenant_id: tenantId,
         conn_id: record.connectionId ?? '',
@@ -123,7 +123,7 @@ export const proofEvents = async (agent: Agent<RestMultiTenantAgentModules>, con
         hop: 'controller.handler.exit',
         flow: 'verification',
         thread_id: threadId ?? '',
-        outer_msg_id: outerMsgId,
+        jwe_fp: jweFp,
         span_id: handlerSpanId,
         tenant_id: tenantId,
         conn_id: record.connectionId ?? '',

--- a/src/instrumentation/metrics.ts
+++ b/src/instrumentation/metrics.ts
@@ -30,6 +30,10 @@ export function recordWebhookFire(): void {
   _webhookFiresLast10s++
 }
 
+export function getSessionPoolStats(): { sessionsInFlight: number; sessionsWaiting: number } {
+  return { sessionsInFlight: _sessionsInFlight, sessionsWaiting: _sessionsWaiting }
+}
+
 export interface ControllerGaugeSnapshot {
   sessions_in_flight: number
   sessions_waiting: number

--- a/src/instrumentation/requestContext.ts
+++ b/src/instrumentation/requestContext.ts
@@ -1,9 +1,9 @@
 import { AsyncLocalStorage } from 'async_hooks'
 
 export interface RequestContext {
-  outerMsgId: string
+  jweFp: string
 }
 
-// Carries per-request context (outer_msg_id extracted at HTTP inbound)
-// through Credo's async processing chain to the event handlers.
+// Carries the JWE fingerprint (`iv`) extracted at HTTP inbound through Credo's
+// async processing chain to event handlers and the session acquire wrapper.
 export const requestContext = new AsyncLocalStorage<RequestContext>()

--- a/src/instrumentation/tenantInstrumented.ts
+++ b/src/instrumentation/tenantInstrumented.ts
@@ -7,7 +7,7 @@ type TenantAgent = any
 import { LogLevel } from '@credo-ts/core'
 
 import { emitStructured, makeSpanId, monoNow, durationMs } from '../utils/StructuredLogger'
-import { sessionAcquireStart, sessionAcquireEnd, sessionAcquireFailed, sessionReleased } from './metrics'
+import { sessionAcquireStart, sessionAcquireEnd, sessionAcquireFailed, sessionReleased, getSessionPoolStats } from './metrics'
 import { requestContext } from './requestContext'
 
 type TenantCallback<T> = (tenantAgent: TenantAgent) => Promise<T>
@@ -21,14 +21,14 @@ export async function withInstrumentedTenantAgent<T>(
   const resolveSpanId = makeSpanId()
   const resolveStart = monoNow()
 
-  const outerMsgId = requestContext.getStore()?.outerMsgId ?? ''
+  const jweFp = requestContext.getStore()?.jweFp ?? ''
 
   emitStructured(LogLevel.debug, {
     hop: 'controller.tenant.resolve.start',
     flow,
     span_id: resolveSpanId,
     tenant_id: tenantId,
-    outer_msg_id: outerMsgId,
+    jwe_fp: jweFp,
   })
 
   // Session acquire timing starts before withTenantAgent (which blocks on the semaphore)
@@ -41,7 +41,7 @@ export async function withInstrumentedTenantAgent<T>(
     flow,
     span_id: acquireSpanId,
     tenant_id: tenantId,
-    outer_msg_id: outerMsgId,
+    jwe_fp: jweFp,
   })
 
   // Tracks whether withTenantAgent entered the callback. If it throws before
@@ -54,22 +54,25 @@ export async function withInstrumentedTenantAgent<T>(
       callbackEntered = true
       const waitMs = durationMs(acquireStart)
       sessionAcquireEnd(waitMs)
+      const { sessionsInFlight, sessionsWaiting } = getSessionPoolStats()
 
       emitStructured(LogLevel.info, {
         hop: 'controller.session.acquire.end',
         flow,
         span_id: acquireSpanId,
         tenant_id: tenantId,
-        outer_msg_id: outerMsgId,
+        jwe_fp: jweFp,
         wait_ms: waitMs,
         duration_ms: waitMs,
+        sessions_in_use: sessionsInFlight,
+        sessions_waiting: sessionsWaiting,
       })
       emitStructured(LogLevel.debug, {
         hop: 'controller.tenant.resolve.end',
         flow,
         span_id: resolveSpanId,
         tenant_id: tenantId,
-        outer_msg_id: outerMsgId,
+        jwe_fp: jweFp,
         duration_ms: durationMs(resolveStart),
       })
 
@@ -110,7 +113,7 @@ export async function withInstrumentedTenantAgent<T>(
         flow,
         span_id: acquireSpanId,
         tenant_id: tenantId,
-        outer_msg_id: outerMsgId,
+        jwe_fp: jweFp,
         duration_ms: durationMs(acquireStart),
         notes: `acquire_failed: ${String(err)}`,
       })

--- a/src/utils/CachedDocumentLoader.ts
+++ b/src/utils/CachedDocumentLoader.ts
@@ -45,7 +45,7 @@ export const buildCachedDocumentLoader = (logger: TsLogger): DocumentLoaderWithC
           emitStructured(LogLevel.info, {
             hop: 'controller.jsonld.context.fetch.end',
             span_id: _fetchSpanId,
-            outer_msg_id: requestContext.getStore()?.outerMsgId ?? '',
+            jwe_fp: requestContext.getStore()?.jweFp ?? '',
             tenant_id: '',
             duration_ms: durationMs(_fetchStart),
             cache_hit: true,
@@ -64,7 +64,7 @@ export const buildCachedDocumentLoader = (logger: TsLogger): DocumentLoaderWithC
       emitStructured(LogLevel.info, {
         hop: 'controller.jsonld.context.fetch.start',
         span_id: _fetchSpanId,
-        outer_msg_id: requestContext.getStore()?.outerMsgId ?? '',
+        jwe_fp: requestContext.getStore()?.jweFp ?? '',
         tenant_id: '',
         cache_hit: false,
         url,
@@ -77,7 +77,7 @@ export const buildCachedDocumentLoader = (logger: TsLogger): DocumentLoaderWithC
         emitStructured(LogLevel.info, {
           hop: 'controller.jsonld.context.fetch.end',
           span_id: _fetchSpanId,
-          outer_msg_id: requestContext.getStore()?.outerMsgId ?? '',
+          jwe_fp: requestContext.getStore()?.jweFp ?? '',
           tenant_id: '',
           duration_ms: durationMs(_fetchStart),
           cache_hit: false,
@@ -87,7 +87,7 @@ export const buildCachedDocumentLoader = (logger: TsLogger): DocumentLoaderWithC
         emitStructured(LogLevel.info, {
           hop: 'controller.jsonld.context.fetch.end',
           span_id: _fetchSpanId,
-          outer_msg_id: requestContext.getStore()?.outerMsgId ?? '',
+          jwe_fp: requestContext.getStore()?.jweFp ?? '',
           tenant_id: '',
           duration_ms: durationMs(_fetchStart),
           cache_hit: false,

--- a/src/utils/StructuredLogger.ts
+++ b/src/utils/StructuredLogger.ts
@@ -36,7 +36,7 @@ export interface StructuredLogLine {
   hop: HopName
   flow?: FlowType
   thread_id?: string
-  outer_msg_id?: string
+  jwe_fp?: string
   recipient_key_short?: string
   tenant_id?: string
   conn_id?: string
@@ -84,36 +84,61 @@ export function truncateKey(key: string): string {
   return key.slice(0, 6) + '…' + key.slice(-6)
 }
 
-export function tryExtractFromJwe(rawBody: string): { recipientKeyShort: string; outerMsgId: string } {
+// Extracts the JWE top-level `iv` as a per-message fingerprint and the recipient key
+// for cross-service log correlation.
+export function tryExtractFromJwe(rawBody: string): { recipientKeyShort: string; jweFp: string } {
   try {
     const parsed = JSON.parse(rawBody) as Record<string, unknown>
     let recipientKeyShort = ''
-    let outerMsgId = ''
 
-    // recipients is a top-level JWE JSON field, not inside the protected header
+    // Try top-level recipients first (standard JWE General JSON Serialization)
     const recipients = parsed['recipients']
     if (Array.isArray(recipients) && recipients.length > 0) {
       const firstRecip = recipients[0] as Record<string, unknown>
       const hdr = firstRecip['header'] as Record<string, unknown> | undefined
       const kid = hdr?.['kid']
-      if (typeof kid === 'string') recipientKeyShort = truncateKey(kid)
+      if (typeof kid === 'string' && kid.length > 0) recipientKeyShort = truncateKey(kid)
     }
 
-    // @id is non-standard in JWE but check the protected header anyway
-    const protectedB64 = parsed['protected']
-    if (typeof protectedB64 === 'string') {
-      try {
-        const headerStr = Buffer.from(protectedB64, 'base64').toString('utf8')
-        const header = JSON.parse(headerStr) as Record<string, unknown>
-        const id = header['@id'] || header['id']
-        if (typeof id === 'string') outerMsgId = id
-      } catch {
-        // ignore
+    // Fall back: Aries DIDComm v1 Authcrypt puts recipients inside the protected header
+    if (!recipientKeyShort) {
+      const protectedB64 = parsed['protected']
+      if (typeof protectedB64 === 'string') {
+        try {
+          const headerStr = Buffer.from(protectedB64, 'base64').toString('utf8')
+          const header = JSON.parse(headerStr) as Record<string, unknown>
+          const innerRecipients = header['recipients']
+          if (Array.isArray(innerRecipients) && innerRecipients.length > 0) {
+            const first = innerRecipients[0] as Record<string, unknown>
+            const hdr = first['header'] as Record<string, unknown> | undefined
+            const kid = hdr?.['kid']
+            if (typeof kid === 'string') recipientKeyShort = truncateKey(kid)
+          }
+        } catch {
+          // ignore
+        }
       }
     }
 
-    return { recipientKeyShort, outerMsgId }
+    // iv fingerprint: unique per JWE encryption, visible at both ends without decryption
+    const iv = parsed['iv']
+    const jweFp = typeof iv === 'string' ? iv : ''
+
+    return { recipientKeyShort, jweFp }
   } catch {
-    return { recipientKeyShort: '', outerMsgId: '' }
+    return { recipientKeyShort: '', jweFp: '' }
+  }
+}
+
+export function tryExtractJweFp(payload: unknown): string {
+  try {
+    const parsed: Record<string, unknown> =
+      typeof payload === 'string'
+        ? (JSON.parse(payload) as Record<string, unknown>)
+        : (payload as Record<string, unknown>)
+    const iv = parsed['iv']
+    return typeof iv === 'string' ? iv : ''
+  } catch {
+    return ''
   }
 }

--- a/src/utils/StructuredLogger.ts
+++ b/src/utils/StructuredLogger.ts
@@ -129,16 +129,3 @@ export function tryExtractFromJwe(rawBody: string): { recipientKeyShort: string;
     return { recipientKeyShort: '', jweFp: '' }
   }
 }
-
-export function tryExtractJweFp(payload: unknown): string {
-  try {
-    const parsed: Record<string, unknown> =
-      typeof payload === 'string'
-        ? (JSON.parse(payload) as Record<string, unknown>)
-        : (payload as Record<string, unknown>)
-    const iv = parsed['iv']
-    return typeof iv === 'string' ? iv : ''
-  } catch {
-    return ''
-  }
-}


### PR DESCRIPTION
## Summary
- Replaces `outer_msg_id` with `jwe_fp` (JWE top-level `iv`) across all event handlers
- ALS `requestContext` threads `jwe_fp` from HTTP inbound into credential/proof event emitters
- Adds `sessions_in_use` + `sessions_waiting` on `controller.session.acquire.end` via new `getSessionPoolStats()` helper