### PR TITLE
chore(instrumentation): default structured-log threshold to warn

### DIFF
--- a/src/cliAgent.ts
+++ b/src/cliAgent.ts
@@ -454,7 +454,7 @@ export async function runRestAgent(restConfig: AriesRestConfig) {
             ? tryExtractFromJwe(raw)
             : { recipientKeyShort: '', jweFp: '' }
           const spanId = makeSpanId()
-          emitStructured(LogLevel.info, {
+          emitStructured(LogLevel.trace, {
             hop: 'controller.http.inbound.received',
             span_id: spanId,
             jwe_fp: jweFp,
@@ -474,7 +474,7 @@ export async function runRestAgent(restConfig: AriesRestConfig) {
 
   await agent.initialize()
 
-  emitStructured(LogLevel.info, {
+  emitStructured(LogLevel.trace, {
     hop: 'controller.config.dump',
     flow: 'lifecycle',
     notes: 'effective config at startup',

--- a/src/events/CredentialEvents.ts
+++ b/src/events/CredentialEvents.ts
@@ -18,7 +18,7 @@ export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>
     const threadId = record.threadId ?? ''
     const jweFp = requestContext.getStore()?.jweFp ?? ''
 
-    emitStructured(LogLevel.info, {
+    emitStructured(LogLevel.trace, {
       hop: 'controller.event.credential.state',
       flow: 'issuance',
       thread_id: threadId,
@@ -45,7 +45,7 @@ export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>
         if (tenantId !== 'default') {
           await withInstrumentedTenantAgent(agent, tenantId, 'issuance', async (tenantAgent) => {
             const handlerStart = monoNow()
-            emitStructured(LogLevel.info, {
+            emitStructured(LogLevel.trace, {
               hop: 'controller.handler.entry',
               flow: 'issuance',
               thread_id: threadId,
@@ -60,7 +60,7 @@ export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>
             ])
             body.credentialData = data
             body.outOfBandId = connectionRecord?.outOfBandId ?? null
-            emitStructured(LogLevel.info, {
+            emitStructured(LogLevel.trace, {
               hop: 'controller.handler.exit',
               flow: 'issuance',
               thread_id: threadId,
@@ -74,7 +74,7 @@ export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>
           })
         } else {
           const handlerStart = monoNow()
-          emitStructured(LogLevel.info, {
+          emitStructured(LogLevel.trace, {
             hop: 'controller.handler.entry',
             flow: 'issuance',
             thread_id: threadId,
@@ -89,7 +89,7 @@ export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>
           ])
           body.credentialData = data
           body.outOfBandId = connectionRecord?.outOfBandId ?? null
-          emitStructured(LogLevel.info, {
+          emitStructured(LogLevel.trace, {
             hop: 'controller.handler.exit',
             flow: 'issuance',
             thread_id: threadId,
@@ -112,7 +112,7 @@ export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>
     } else {
       // Non-Done states: no session acquire involved — wrap the full (instant) handler.
       const handlerStart = monoNow()
-      emitStructured(LogLevel.info, {
+      emitStructured(LogLevel.trace, {
         hop: 'controller.handler.entry',
         flow: 'issuance',
         thread_id: threadId,
@@ -121,7 +121,7 @@ export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>
         tenant_id: tenantId,
         conn_id: record.connectionId ?? '',
       })
-      emitStructured(LogLevel.info, {
+      emitStructured(LogLevel.trace, {
         hop: 'controller.handler.exit',
         flow: 'issuance',
         thread_id: threadId,
@@ -138,7 +138,7 @@ export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>
     if (config.webhookUrl) {
       const webhookSpanId = makeSpanId()
       const webhookStart = monoNow()
-      emitStructured(LogLevel.info, {
+      emitStructured(LogLevel.trace, {
         hop: 'controller.webhook.fire.start',
         flow: 'issuance',
         thread_id: threadId,
@@ -148,7 +148,7 @@ export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>
       })
       recordWebhookFire()
       sendWebhookEvent(config.webhookUrl + '/credentials', body, agent.config.logger)
-      emitStructured(LogLevel.info, {
+      emitStructured(LogLevel.trace, {
         hop: 'controller.webhook.fire.end',
         flow: 'issuance',
         thread_id: threadId,

--- a/src/events/ProofEvents.ts
+++ b/src/events/ProofEvents.ts
@@ -24,7 +24,7 @@ export const proofEvents = async (agent: Agent<RestMultiTenantAgentModules>, con
 
     const jweFp = requestContext.getStore()?.jweFp ?? ''
 
-    emitStructured(LogLevel.info, {
+    emitStructured(LogLevel.trace, {
       hop: 'controller.event.proof.state',
       flow: 'verification',
       thread_id: threadId ?? '',
@@ -46,7 +46,7 @@ export const proofEvents = async (agent: Agent<RestMultiTenantAgentModules>, con
         if (tenantId !== 'default') {
           await withInstrumentedTenantAgent(agent, tenantId, 'verification', async (tenantAgent) => {
             const handlerStart = monoNow()
-            emitStructured(LogLevel.info, {
+            emitStructured(LogLevel.trace, {
               hop: 'controller.handler.entry',
               flow: 'verification',
               thread_id: threadId ?? '',
@@ -60,7 +60,7 @@ export const proofEvents = async (agent: Agent<RestMultiTenantAgentModules>, con
             agent.config.logger.debug(
               `[ProofEvent] Fetched proof format data for tenant agent - threadId=${threadId}, state=${state}, tenantId=${tenantId}, data=${JSON.stringify(body)}`
             )
-            emitStructured(LogLevel.info, {
+            emitStructured(LogLevel.trace, {
               hop: 'controller.handler.exit',
               flow: 'verification',
               thread_id: threadId ?? '',
@@ -74,7 +74,7 @@ export const proofEvents = async (agent: Agent<RestMultiTenantAgentModules>, con
           })
         } else {
           const handlerStart = monoNow()
-          emitStructured(LogLevel.info, {
+          emitStructured(LogLevel.trace, {
             hop: 'controller.handler.entry',
             flow: 'verification',
             thread_id: threadId ?? '',
@@ -88,7 +88,7 @@ export const proofEvents = async (agent: Agent<RestMultiTenantAgentModules>, con
           agent.config.logger.debug(
             `[ProofEvent] Fetched proof format data for default agent - threadId=${threadId}, state=${state}, data=${JSON.stringify(body)}`
           )
-          emitStructured(LogLevel.info, {
+          emitStructured(LogLevel.trace, {
             hop: 'controller.handler.exit',
             flow: 'verification',
             thread_id: threadId ?? '',
@@ -110,7 +110,7 @@ export const proofEvents = async (agent: Agent<RestMultiTenantAgentModules>, con
     } else {
       // Non-Done states: no session acquire involved — wrap the full (instant) handler.
       const handlerStart = monoNow()
-      emitStructured(LogLevel.info, {
+      emitStructured(LogLevel.trace, {
         hop: 'controller.handler.entry',
         flow: 'verification',
         thread_id: threadId ?? '',
@@ -119,7 +119,7 @@ export const proofEvents = async (agent: Agent<RestMultiTenantAgentModules>, con
         tenant_id: tenantId,
         conn_id: record.connectionId ?? '',
       })
-      emitStructured(LogLevel.info, {
+      emitStructured(LogLevel.trace, {
         hop: 'controller.handler.exit',
         flow: 'verification',
         thread_id: threadId ?? '',
@@ -139,7 +139,7 @@ export const proofEvents = async (agent: Agent<RestMultiTenantAgentModules>, con
       )
       const webhookSpanId = makeSpanId()
       const webhookStart = monoNow()
-      emitStructured(LogLevel.info, {
+      emitStructured(LogLevel.trace, {
         hop: 'controller.webhook.fire.start',
         flow: 'verification',
         thread_id: threadId ?? '',
@@ -149,7 +149,7 @@ export const proofEvents = async (agent: Agent<RestMultiTenantAgentModules>, con
       })
       recordWebhookFire()
       sendWebhookEvent(config.webhookUrl + '/proofs', body, agent.config.logger)
-      emitStructured(LogLevel.info, {
+      emitStructured(LogLevel.trace, {
         hop: 'controller.webhook.fire.end',
         flow: 'verification',
         thread_id: threadId ?? '',

--- a/src/instrumentation/gauges.ts
+++ b/src/instrumentation/gauges.ts
@@ -11,7 +11,7 @@ export function startGauges(): void {
   if (_gaugeTimer) return
   _gaugeTimer = setInterval(() => {
     const snap = snapshotAndReset()
-    emitStructured(LogLevel.info, {
+    emitStructured(LogLevel.trace, {
       hop: 'controller.gauge.snapshot',
       flow: 'lifecycle',
       ...snap,

--- a/src/instrumentation/logLevelHolder.ts
+++ b/src/instrumentation/logLevelHolder.ts
@@ -1,10 +1,10 @@
 import { LogLevel } from '@credo-ts/core'
 
-// Default threshold for emitStructured() instrumentation hops. At `warn`, all the info/debug
-// trace hops (controller.handler.*, event.credential/proof.state, session.acquire,
-// jsonld.context.fetch, webhook.fire, gauge.snapshot, http.inbound.received, etc.) are
-// suppressed — production stays quiet by default. Raise it to `info` or `debug` at runtime via
-// POST /admin/log-level when investigating; no redeploy needed.
+// Default threshold for emitStructured() instrumentation hops. The instrumentation emits at
+// `trace`, so at the `warn` default every hop (controller.handler.*, event.credential/proof.state,
+// session.acquire, jsonld.context.fetch, webhook.fire, gauge.snapshot, etc.) is suppressed —
+// production stays quiet by default. To capture them, set the level to `trace` at runtime via
+// POST /admin/log-level (the deepest, explicitly-enabled level); no redeploy needed.
 let _level: LogLevel = LogLevel.warn
 
 export function getDebugLogLevel(): LogLevel {

--- a/src/instrumentation/logLevelHolder.ts
+++ b/src/instrumentation/logLevelHolder.ts
@@ -1,6 +1,11 @@
 import { LogLevel } from '@credo-ts/core'
 
-let _level: LogLevel = LogLevel.info
+// Default threshold for emitStructured() instrumentation hops. At `warn`, all the info/debug
+// trace hops (controller.handler.*, event.credential/proof.state, session.acquire,
+// jsonld.context.fetch, webhook.fire, gauge.snapshot, http.inbound.received, etc.) are
+// suppressed — production stays quiet by default. Raise it to `info` or `debug` at runtime via
+// POST /admin/log-level when investigating; no redeploy needed.
+let _level: LogLevel = LogLevel.warn
 
 export function getDebugLogLevel(): LogLevel {
   return _level

--- a/src/instrumentation/tenantInstrumented.ts
+++ b/src/instrumentation/tenantInstrumented.ts
@@ -23,7 +23,7 @@ export async function withInstrumentedTenantAgent<T>(
 
   const jweFp = requestContext.getStore()?.jweFp ?? ''
 
-  emitStructured(LogLevel.debug, {
+  emitStructured(LogLevel.trace, {
     hop: 'controller.tenant.resolve.start',
     flow,
     span_id: resolveSpanId,
@@ -36,7 +36,7 @@ export async function withInstrumentedTenantAgent<T>(
   const acquireStart = monoNow()
   sessionAcquireStart()
 
-  emitStructured(LogLevel.info, {
+  emitStructured(LogLevel.trace, {
     hop: 'controller.session.acquire.start',
     flow,
     span_id: acquireSpanId,
@@ -56,7 +56,7 @@ export async function withInstrumentedTenantAgent<T>(
       sessionAcquireEnd(waitMs)
       const { sessionsInFlight, sessionsWaiting } = getSessionPoolStats()
 
-      emitStructured(LogLevel.info, {
+      emitStructured(LogLevel.trace, {
         hop: 'controller.session.acquire.end',
         flow,
         span_id: acquireSpanId,
@@ -67,7 +67,7 @@ export async function withInstrumentedTenantAgent<T>(
         sessions_in_use: sessionsInFlight,
         sessions_waiting: sessionsWaiting,
       })
-      emitStructured(LogLevel.debug, {
+      emitStructured(LogLevel.trace, {
         hop: 'controller.tenant.resolve.end',
         flow,
         span_id: resolveSpanId,
@@ -79,7 +79,7 @@ export async function withInstrumentedTenantAgent<T>(
       // Measure first Askar access (wallet open / profile attach) for H8.
       const walletSpanId = makeSpanId()
       const walletStart = monoNow()
-      emitStructured(LogLevel.debug, {
+      emitStructured(LogLevel.trace, {
         hop: 'controller.wallet.open.start',
         flow,
         span_id: walletSpanId,
@@ -92,7 +92,7 @@ export async function withInstrumentedTenantAgent<T>(
       } catch {
         // ignore — only measuring timing; the callback may not need genericRecords
       }
-      emitStructured(LogLevel.debug, {
+      emitStructured(LogLevel.trace, {
         hop: 'controller.wallet.open.end',
         flow,
         span_id: walletSpanId,
@@ -108,7 +108,7 @@ export async function withInstrumentedTenantAgent<T>(
       // withTenantAgent failed before the session was acquired (semaphore timeout,
       // invalid tenant, etc.). Decrement waiting without touching in-flight.
       sessionAcquireFailed()
-      emitStructured(LogLevel.info, {
+      emitStructured(LogLevel.trace, {
         hop: 'controller.session.acquire.end',
         flow,
         span_id: acquireSpanId,

--- a/src/utils/CachedDocumentLoader.ts
+++ b/src/utils/CachedDocumentLoader.ts
@@ -42,7 +42,7 @@ export const buildCachedDocumentLoader = (logger: TsLogger): DocumentLoaderWithC
 
         if (cached) {
           logger.debug(`Document loader cache hit for: ${url}`)
-          emitStructured(LogLevel.info, {
+          emitStructured(LogLevel.trace, {
             hop: 'controller.jsonld.context.fetch.end',
             span_id: _fetchSpanId,
             jwe_fp: requestContext.getStore()?.jweFp ?? '',
@@ -61,7 +61,7 @@ export const buildCachedDocumentLoader = (logger: TsLogger): DocumentLoaderWithC
       // Cache miss — fetch via default loader
       logger.debug(`Document loader cache miss — fetching: ${url}`)
 
-      emitStructured(LogLevel.info, {
+      emitStructured(LogLevel.trace, {
         hop: 'controller.jsonld.context.fetch.start',
         span_id: _fetchSpanId,
         jwe_fp: requestContext.getStore()?.jweFp ?? '',
@@ -74,7 +74,7 @@ export const buildCachedDocumentLoader = (logger: TsLogger): DocumentLoaderWithC
 
       try {
         document = await defaultLoader(url)
-        emitStructured(LogLevel.info, {
+        emitStructured(LogLevel.trace, {
           hop: 'controller.jsonld.context.fetch.end',
           span_id: _fetchSpanId,
           jwe_fp: requestContext.getStore()?.jweFp ?? '',
@@ -84,7 +84,7 @@ export const buildCachedDocumentLoader = (logger: TsLogger): DocumentLoaderWithC
           url,
         })
       } catch (err) {
-        emitStructured(LogLevel.info, {
+        emitStructured(LogLevel.trace, {
           hop: 'controller.jsonld.context.fetch.end',
           span_id: _fetchSpanId,
           jwe_fp: requestContext.getStore()?.jweFp ?? '',


### PR DESCRIPTION
The emitStructured() gate defaulted to info, so every controller trace hop (handler.entry/exit, event.credential/proof.state, session.acquire, jsonld.context.fetch, webhook.fire, gauge.snapshot, http.inbound.received) printed in production on every boot — heavy and on by default.

Default to warn so the instrumentation is silent by default; flip to info/debug at runtime via POST /admin/log-level during an investigation. No env var, no redeploy needed. Mirrors the same change in ngotag-mediator. Set instrumentation log level to trace.