### PR TITLE
fix: Pick ETH related env vars from .env file to automate deployment

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -26,6 +26,18 @@ windowMs=
 maxRateLimit=
 # Specify Did contract address
 DID_CONTRACT_ADDRESS=
+# Specify Ethereum network name
+ETHEREUM_NETWORK_NAME=
+# Specify Ethereum chain id
+ETHEREUM_CHAIN_ID=
+# Specify Ethereum network RPC URL
+ETHEREUM_NETWORK_RPC_URL=
+# Specify Ethereum DID registry contract address
+ETHEREUM_DID_REGISTRY_CONTRACT_ADDRESS=
+# Specify Ethereum Schema Manager contract address
+ETHEREUM_SCHEMA_MANAGER_CONTRACT_ADDRESS=
+# Specify Ethereum module RPC URL
+ETHEREUM_RPC_URL=
 REDIS_URL=
 REDIS_CACHE_TTL_SECONDS=
 

--- a/.env.sample
+++ b/.env.sample
@@ -30,13 +30,11 @@ DID_CONTRACT_ADDRESS=
 ETHEREUM_NETWORK_NAME=
 # Specify Ethereum chain id
 ETHEREUM_CHAIN_ID=
-# Specify Ethereum network RPC URL
-ETHEREUM_NETWORK_RPC_URL=
 # Specify Ethereum DID registry contract address
 ETHEREUM_DID_REGISTRY_CONTRACT_ADDRESS=
 # Specify Ethereum Schema Manager contract address
 ETHEREUM_SCHEMA_MANAGER_CONTRACT_ADDRESS=
-# Specify Ethereum module RPC URL
+# Specify Ethereum RPC URL
 ETHEREUM_RPC_URL=
 REDIS_URL=
 REDIS_CACHE_TTL_SECONDS=

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,7 +44,6 @@ interface Parsed {
   fileServerToken?: string
   ethereumNetworkName?: string
   ethereumChainId?: string
-  ethereumNetworkRpcUrl?: string
   ethereumRegistry?: string
   ethereumSchemaManagerContractAddress?: string
   ethereumRpcUrl?: string
@@ -121,10 +120,6 @@ async function parseArguments(): Promise<Parsed> {
       demandOption: false,
     })
     .option('ethereum-chain-id', {
-      string: true,
-      demandOption: false,
-    })
-    .option('ethereum-network-rpc-url', {
       string: true,
       demandOption: false,
     })
@@ -299,7 +294,6 @@ export async function runCliServer() {
     fileServerToken: parsed['fileServerToken'],
     ethereumNetworkName: parsed['ethereumNetworkName'] || parsed['chainName'],
     ethereumChainId: parsed['ethereumChainId'] || parsed['chainId'],
-    ethereumNetworkRpcUrl: parsed['ethereumNetworkRpcUrl'],
     ethereumRegistry: parsed['ethereumRegistry'] || parsed['registry'],
     ethereumSchemaManagerContractAddress: parsed['ethereumSchemaManagerContractAddress'],
     ethereumRpcUrl: parsed['ethereumRpcUrl'],

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -42,6 +42,12 @@ interface Parsed {
   rpcUrl?: string
   fileServerUrl?: string
   fileServerToken?: string
+  ethereumNetworkName?: string
+  ethereumChainId?: string
+  ethereumNetworkRpcUrl?: string
+  ethereumRegistry?: string
+  ethereumSchemaManagerContractAddress?: string
+  ethereumRpcUrl?: string
   chainId?: string
   chainName?: string
   registry?: string
@@ -98,7 +104,7 @@ async function parseArguments(): Promise<Parsed> {
       string: true,
       demandOption: true,
     })
-     .option('chainId', {
+    .option('chainId', {
       string: true,
       demandOption: false,
     })
@@ -107,6 +113,30 @@ async function parseArguments(): Promise<Parsed> {
       demandOption: false,
     })
     .option('registry', {
+      string: true,
+      demandOption: false,
+    })
+    .option('ethereum-network-name', {
+      string: true,
+      demandOption: false,
+    })
+    .option('ethereum-chain-id', {
+      string: true,
+      demandOption: false,
+    })
+    .option('ethereum-network-rpc-url', {
+      string: true,
+      demandOption: false,
+    })
+    .option('ethereum-registry', {
+      string: true,
+      demandOption: false,
+    })
+    .option('ethereum-schema-manager-contract-address', {
+      string: true,
+      demandOption: false,
+    })
+    .option('ethereum-rpc-url', {
       string: true,
       demandOption: false,
     })
@@ -267,8 +297,11 @@ export async function runCliServer() {
     rpcUrl: parsed['rpcUrl'],
     fileServerUrl: parsed['fileServerUrl'],
     fileServerToken: parsed['fileServerToken'],
-    chainId: parsed['chainId'],
-    name: parsed['chainName'],
-    registry: parsed['registry'],
+    ethereumNetworkName: parsed['ethereumNetworkName'] || parsed['chainName'],
+    ethereumChainId: parsed['ethereumChainId'] || parsed['chainId'],
+    ethereumNetworkRpcUrl: parsed['ethereumNetworkRpcUrl'],
+    ethereumRegistry: parsed['ethereumRegistry'] || parsed['registry'],
+    ethereumSchemaManagerContractAddress: parsed['ethereumSchemaManagerContractAddress'],
+    ethereumRpcUrl: parsed['ethereumRpcUrl'],
   } as unknown as AriesRestConfig)
 }

--- a/src/cliAgent.ts
+++ b/src/cliAgent.ts
@@ -106,6 +106,15 @@ export interface AriesRestConfig {
   rpcUrl?: string
   fileServerUrl?: string
   fileServerToken?: string
+  ethereumNetworkName?: string
+  ethereumChainId?: string | number
+  ethereumNetworkRpcUrl?: string
+  ethereumRegistry?: string
+  ethereumSchemaManagerContractAddress?: string
+  ethereumRpcUrl?: string
+  chainId?: string | number
+  name?: string
+  registry?: string
   walletScheme?: AskarMultiWalletDatabaseScheme
   schemaFileServerURL?: string
 }
@@ -120,6 +129,15 @@ export async function readRestConfig(path: string) {
 export type RestMultiTenantAgentModules = Awaited<ReturnType<typeof getWithTenantModules>>
 
 export type RestAgentModules = Awaited<ReturnType<typeof getModules>>
+
+interface EthereumModuleEnvironmentConfig {
+  ethereumNetworkName?: string
+  ethereumChainId?: string | number
+  ethereumNetworkRpcUrl?: string
+  ethereumRegistry?: string
+  ethereumSchemaManagerContractAddress?: string
+  ethereumRpcUrl?: string
+}
 
 const initializeCache = (logger: TsLogger) => {
   const redisUrl = process.env.REDIS_URL
@@ -147,8 +165,22 @@ const getModules = (
   autoAcceptCredentials: AutoAcceptCredential,
   autoAcceptProofs: AutoAcceptProof,
   walletScheme: AskarMultiWalletDatabaseScheme,
-  logger: TsLogger
+  logger: TsLogger,
+  ethereumModuleConfig: EthereumModuleEnvironmentConfig = {}
 ) => {
+  const ethereumNetworkName = ethereumModuleConfig.ethereumNetworkName || process.env.ETHEREUM_NETWORK_NAME
+  const ethereumChainId = Number(ethereumModuleConfig.ethereumChainId || process.env.ETHEREUM_CHAIN_ID)
+  const ethereumNetworkRpcUrl =
+    ethereumModuleConfig.ethereumNetworkRpcUrl || process.env.ETHEREUM_NETWORK_RPC_URL
+  const ethereumRegistry =
+    ethereumModuleConfig.ethereumRegistry ||
+    process.env.ETHEREUM_DID_REGISTRY_CONTRACT_ADDRESS ||
+    process.env.ETHEREUM_REGISTRY
+  const ethereumSchemaManagerContractAddress =
+    ethereumModuleConfig.ethereumSchemaManagerContractAddress ||
+    process.env.ETHEREUM_SCHEMA_MANAGER_CONTRACT_ADDRESS
+  const ethereumRpcUrl = ethereumModuleConfig.ethereumRpcUrl || process.env.ETHEREUM_RPC_URL
+
   const legacyIndyCredentialFormat = new LegacyIndyCredentialFormatService()
   const legacyIndyProofFormat = new LegacyIndyProofFormatService()
   const jsonLdCredentialFormatService = new JsonLdCredentialFormatService()
@@ -238,17 +270,17 @@ const getModules = (
       config: {
         networks: [
           {
-            name: 'sepolia',
-            chainId: 11155111,
-            rpcUrl: 'https://ethereum-sepolia-rpc.publicnode.com',
-            registry: '0x485cFb9cdB84c0a5AfE69b75E2e79497Fc2256Fc',
+            name: ethereumNetworkName as string,
+            chainId: ethereumChainId,
+            rpcUrl: ethereumNetworkRpcUrl as string,
+            registry: ethereumRegistry as string,
           },
         ],
       },
-      schemaManagerContractAddress: '0xa95ACF3119791F65b2192267836df9A472785c15',
-      serverUrl: 'https://dev-schema.ngotag.com',
-      fileServerToken: 'ACCESS-TOKEN',
-      rpcUrl: 'https://eth-sepolia.g.alchemy.com/v2/API-KEY',
+      schemaManagerContractAddress: ethereumSchemaManagerContractAddress as string,
+      serverUrl: fileServerUrl ? fileServerUrl : (process.env.SERVER_URL as string),
+      fileServerToken: fileServerToken ? fileServerToken : (process.env.FILE_SERVER_TOKEN as string),
+      rpcUrl: ethereumRpcUrl as string,
     }),
   }
 }
@@ -265,7 +297,8 @@ const getWithTenantModules = (
   autoAcceptCredentials: AutoAcceptCredential,
   autoAcceptProofs: AutoAcceptProof,
   walletScheme: AskarMultiWalletDatabaseScheme,
-  logger: TsLogger
+  logger: TsLogger,
+  ethereumModuleConfig: EthereumModuleEnvironmentConfig = {}
 ) => {
   const modules = getModules(
     networkConfig,
@@ -278,7 +311,8 @@ const getWithTenantModules = (
     autoAcceptCredentials,
     autoAcceptProofs,
     walletScheme,
-    logger
+    logger,
+    ethereumModuleConfig
   )
   return {
     tenants: new TenantsModule<typeof modules>({
@@ -320,6 +354,15 @@ export async function runRestAgent(restConfig: AriesRestConfig) {
     fileServerUrl,
     rpcUrl,
     schemaManagerContractAddress,
+    ethereumNetworkName,
+    ethereumChainId,
+    ethereumNetworkRpcUrl,
+    ethereumRegistry,
+    ethereumSchemaManagerContractAddress,
+    ethereumRpcUrl,
+    chainId,
+    name,
+    registry,
     walletConfig,
     autoAcceptConnections,
     autoAcceptCredentials,
@@ -399,6 +442,15 @@ export async function runRestAgent(restConfig: AriesRestConfig) {
     ]
   }
 
+  const ethereumModuleConfig = {
+    ethereumNetworkName: ethereumNetworkName || name,
+    ethereumChainId: ethereumChainId || chainId,
+    ethereumNetworkRpcUrl,
+    ethereumRegistry: ethereumRegistry || registry,
+    ethereumSchemaManagerContractAddress,
+    ethereumRpcUrl,
+  }
+
   const tenantModule = await getWithTenantModules(
     networkConfig,
     didRegistryContractAddress || '',
@@ -410,7 +462,8 @@ export async function runRestAgent(restConfig: AriesRestConfig) {
     autoAcceptCredentials || AutoAcceptCredential.Always,
     autoAcceptProofs || AutoAcceptProof.ContentApproved,
     walletScheme || AskarMultiWalletDatabaseScheme.ProfilePerWallet,
-    logger
+    logger,
+    ethereumModuleConfig
   )
   const modules = getModules(
     networkConfig,
@@ -423,7 +476,8 @@ export async function runRestAgent(restConfig: AriesRestConfig) {
     autoAcceptCredentials || AutoAcceptCredential.Always,
     autoAcceptProofs || AutoAcceptProof.ContentApproved,
     walletScheme || AskarMultiWalletDatabaseScheme.ProfilePerWallet,
-    logger
+    logger,
+    ethereumModuleConfig
   )
   const agent = new Agent({
     config: agentConfig,

--- a/src/cliAgent.ts
+++ b/src/cliAgent.ts
@@ -111,9 +111,6 @@ export interface AriesRestConfig {
   ethereumRegistry?: string
   ethereumSchemaManagerContractAddress?: string
   ethereumRpcUrl?: string
-  chainId?: string | number
-  name?: string
-  registry?: string
   walletScheme?: AskarMultiWalletDatabaseScheme
   schemaFileServerURL?: string
 }
@@ -169,10 +166,7 @@ const getModules = (
   const ethereumNetworkName = ethereumModuleConfig.ethereumNetworkName || process.env.ETHEREUM_NETWORK_NAME
   const ethereumChainId = Number(ethereumModuleConfig.ethereumChainId || process.env.ETHEREUM_CHAIN_ID)
   const ethereumRpcUrl = ethereumModuleConfig.ethereumRpcUrl || process.env.ETHEREUM_RPC_URL
-  const ethereumRegistry =
-    ethereumModuleConfig.ethereumRegistry ||
-    process.env.ETHEREUM_DID_REGISTRY_CONTRACT_ADDRESS ||
-    process.env.ETHEREUM_REGISTRY
+  const ethereumRegistry = ethereumModuleConfig.ethereumRegistry || process.env.ETHEREUM_DID_REGISTRY_CONTRACT_ADDRESS
   const ethereumSchemaManagerContractAddress =
     ethereumModuleConfig.ethereumSchemaManagerContractAddress ||
     process.env.ETHEREUM_SCHEMA_MANAGER_CONTRACT_ADDRESS
@@ -355,9 +349,6 @@ export async function runRestAgent(restConfig: AriesRestConfig) {
     ethereumRegistry,
     ethereumSchemaManagerContractAddress,
     ethereumRpcUrl,
-    chainId,
-    name,
-    registry,
     walletConfig,
     autoAcceptConnections,
     autoAcceptCredentials,
@@ -438,9 +429,9 @@ export async function runRestAgent(restConfig: AriesRestConfig) {
   }
 
   const ethereumModuleConfig = {
-    ethereumNetworkName: ethereumNetworkName || name,
-    ethereumChainId: ethereumChainId || chainId,
-    ethereumRegistry: ethereumRegistry || registry,
+    ethereumNetworkName,
+    ethereumChainId,
+    ethereumRegistry,
     ethereumSchemaManagerContractAddress,
     ethereumRpcUrl,
   }

--- a/src/cliAgent.ts
+++ b/src/cliAgent.ts
@@ -108,7 +108,6 @@ export interface AriesRestConfig {
   fileServerToken?: string
   ethereumNetworkName?: string
   ethereumChainId?: string | number
-  ethereumNetworkRpcUrl?: string
   ethereumRegistry?: string
   ethereumSchemaManagerContractAddress?: string
   ethereumRpcUrl?: string
@@ -133,7 +132,6 @@ export type RestAgentModules = Awaited<ReturnType<typeof getModules>>
 interface EthereumModuleEnvironmentConfig {
   ethereumNetworkName?: string
   ethereumChainId?: string | number
-  ethereumNetworkRpcUrl?: string
   ethereumRegistry?: string
   ethereumSchemaManagerContractAddress?: string
   ethereumRpcUrl?: string
@@ -170,8 +168,7 @@ const getModules = (
 ) => {
   const ethereumNetworkName = ethereumModuleConfig.ethereumNetworkName || process.env.ETHEREUM_NETWORK_NAME
   const ethereumChainId = Number(ethereumModuleConfig.ethereumChainId || process.env.ETHEREUM_CHAIN_ID)
-  const ethereumNetworkRpcUrl =
-    ethereumModuleConfig.ethereumNetworkRpcUrl || process.env.ETHEREUM_NETWORK_RPC_URL
+  const ethereumRpcUrl = ethereumModuleConfig.ethereumRpcUrl || process.env.ETHEREUM_RPC_URL
   const ethereumRegistry =
     ethereumModuleConfig.ethereumRegistry ||
     process.env.ETHEREUM_DID_REGISTRY_CONTRACT_ADDRESS ||
@@ -179,7 +176,6 @@ const getModules = (
   const ethereumSchemaManagerContractAddress =
     ethereumModuleConfig.ethereumSchemaManagerContractAddress ||
     process.env.ETHEREUM_SCHEMA_MANAGER_CONTRACT_ADDRESS
-  const ethereumRpcUrl = ethereumModuleConfig.ethereumRpcUrl || process.env.ETHEREUM_RPC_URL
 
   const legacyIndyCredentialFormat = new LegacyIndyCredentialFormatService()
   const legacyIndyProofFormat = new LegacyIndyProofFormatService()
@@ -272,7 +268,7 @@ const getModules = (
           {
             name: ethereumNetworkName as string,
             chainId: ethereumChainId,
-            rpcUrl: ethereumNetworkRpcUrl as string,
+            rpcUrl: ethereumRpcUrl as string,
             registry: ethereumRegistry as string,
           },
         ],
@@ -356,7 +352,6 @@ export async function runRestAgent(restConfig: AriesRestConfig) {
     schemaManagerContractAddress,
     ethereumNetworkName,
     ethereumChainId,
-    ethereumNetworkRpcUrl,
     ethereumRegistry,
     ethereumSchemaManagerContractAddress,
     ethereumRpcUrl,
@@ -445,7 +440,6 @@ export async function runRestAgent(restConfig: AriesRestConfig) {
   const ethereumModuleConfig = {
     ethereumNetworkName: ethereumNetworkName || name,
     ethereumChainId: ethereumChainId || chainId,
-    ethereumNetworkRpcUrl,
     ethereumRegistry: ethereumRegistry || registry,
     ethereumSchemaManagerContractAddress,
     ethereumRpcUrl,


### PR DESCRIPTION
**What does this PR do?**
- All the ETH related environment variables are currently injected from inside `cliAgent.ts`
- This requires manual image build
- To automate deployment, following env vars are made to be read from `.env`  during runtime
```
ETHEREUM_NETWORK_NAME=
ETHEREUM_CHAIN_ID=
ETHEREUM_NETWORK_RPC_URL=
ETHEREUM_DID_REGISTRY_CONTRACT_ADDRESS=
ETHEREUM_SCHEMA_MANAGER_CONTRACT_ADDRESS=
ETHEREUM_RPC_URL=
```