### PR TITLE
fix(tenants): prevent agent-context session pool freeze (release slot on all paths)

### DIFF
--- a/patches/@credo-ts+tenants+0.5.3+002+session-release-exception-safe.patch
+++ b/patches/@credo-ts+tenants+0.5.3+002+session-release-exception-safe.patch
@@ -1,0 +1,99 @@
+diff --git a/node_modules/@credo-ts/tenants/build/TenantsApi.js b/node_modules/@credo-ts/tenants/build/TenantsApi.js
+--- a/node_modules/@credo-ts/tenants/build/TenantsApi.js
++++ b/node_modules/@credo-ts/tenants/build/TenantsApi.js
+@@ -29,7 +29,20 @@
+         const tenantContext = await this.agentContextProvider.getAgentContextForContextCorrelationId(tenantId);
+         this.logger.trace(`Got tenant context for tenant '${tenantId}'`);
+         const tenantAgent = new TenantAgent_1.TenantAgent(tenantContext);
+-        await tenantAgent.initialize();
++        try {
++            await tenantAgent.initialize();
++        }
++        catch (error) {
++            // PATCH(+002): the session slot was already acquired inside
++            // getAgentContextForContextCorrelationId. If initialize() fails, withTenantAgent's
++            // finally is never reached, so we must release the slot here or the global session
++            // counter leaks and the pool wedges at SESSION_LIMIT.
++            try {
++                await tenantAgent.endSession();
++            }
++            catch (_) { /* best-effort release */ }
++            throw error;
++        }
+         this.logger.trace(`Initializing tenant agent for tenant '${tenantId}'`);
+         return tenantAgent;
+     }
+diff --git a/node_modules/@credo-ts/tenants/build/context/TenantSessionMutex.js b/node_modules/@credo-ts/tenants/build/context/TenantSessionMutex.js
+--- a/node_modules/@credo-ts/tenants/build/context/TenantSessionMutex.js
++++ b/node_modules/@credo-ts/tenants/build/context/TenantSessionMutex.js
+@@ -54,7 +54,15 @@
+         // If we reached the limit we should lock the session mutex
+         if (this.currentSessions >= this.maxSessions) {
+             this.logger.debug(`Reached max number of sessions ${this.maxSessions}, locking mutex`);
+-            await this.sessionMutex.acquire();
++            try {
++                await this.sessionMutex.acquire();
++            }
++            catch (error) {
++                // PATCH(+002): the post-increment lock timed out. currentSessions was already
++                // incremented above, so undo it before propagating or the slot leaks permanently.
++                this.currentSessions--;
++                throw error;
++            }
+         }
+         this.logger.debug(`Acquired tenant session (${this.currentSessions} / ${this.maxSessions})`);
+     }
+diff --git a/node_modules/@credo-ts/tenants/build/context/TenantSessionCoordinator.js b/node_modules/@credo-ts/tenants/build/context/TenantSessionCoordinator.js
+--- a/node_modules/@credo-ts/tenants/build/context/TenantSessionCoordinator.js
++++ b/node_modules/@credo-ts/tenants/build/context/TenantSessionCoordinator.js
+@@ -118,24 +118,33 @@
+             this.logger.debug('Ending session for root agent context. Not disposing dependency manager');
+             return;
+         }
+-        // This should not happen
+-        if (!hasTenantSessionMapping) {
+-            this.logger.error(`Unknown agent context with contextCorrelationId '${agentContext.contextCorrelationId}'.  Cannot end session`);
+-            throw new core_1.CredoError(`Unknown agent context with contextCorrelationId '${agentContext.contextCorrelationId}'. Cannot end session`);
+-        }
+-        await this.mutexForTenant(agentContext.contextCorrelationId).runExclusive(async () => {
+-            this.logger.debug(`Acquired lock for tenant '${agentContext.contextCorrelationId}' to end session context`);
+-            const tenantSessions = this.getTenantSessionsMapping(agentContext.contextCorrelationId);
+-            // TODO: check if session count is already 0
+-            tenantSessions.sessionCount--;
+-            this.logger.debug(`Decreased agent context session count for tenant '${agentContext.contextCorrelationId}' to ${tenantSessions.sessionCount}`);
+-            if (tenantSessions.sessionCount <= 0 && tenantSessions.agentContext) {
+-                await this.closeAgentContext(tenantSessions.agentContext);
+-                delete this.tenantAgentContextMapping[agentContext.contextCorrelationId];
++        // PATCH(+002): a session slot was acquired for this context, so it MUST be released on
++        // every exit path. Previously an early throw (unknown mapping) or a rejection from the
++        // runExclusive block below skipped releaseSession(), leaking the slot and eventually
++        // wedging the pool at SESSION_LIMIT. Release now runs in a finally, and an
++        // already-closed mapping no longer throws-and-strands the slot.
++        try {
++            // This should not happen (mapping already closed by a concurrent sibling).
++            if (!hasTenantSessionMapping) {
++                this.logger.warn(`Unknown agent context with contextCorrelationId '${agentContext.contextCorrelationId}' on endSession; releasing session slot anyway`);
++                return;
+             }
+-        });
+-        // Release a session so new sessions can be acquired
+-        this.sessionMutex.releaseSession();
++            await this.mutexForTenant(agentContext.contextCorrelationId).runExclusive(async () => {
++                this.logger.debug(`Acquired lock for tenant '${agentContext.contextCorrelationId}' to end session context`);
++                const tenantSessions = this.getTenantSessionsMapping(agentContext.contextCorrelationId);
++                // TODO: check if session count is already 0
++                tenantSessions.sessionCount--;
++                this.logger.debug(`Decreased agent context session count for tenant '${agentContext.contextCorrelationId}' to ${tenantSessions.sessionCount}`);
++                if (tenantSessions.sessionCount <= 0 && tenantSessions.agentContext) {
++                    await this.closeAgentContext(tenantSessions.agentContext);
++                    delete this.tenantAgentContextMapping[agentContext.contextCorrelationId];
++                }
++            });
++        }
++        finally {
++            // Release a session so new sessions can be acquired
++            this.sessionMutex.releaseSession();
++        }
+     }
+     hasTenantSessionMapping(tenantId) {
+         return this.tenantAgentContextMapping[tenantId] !== undefined;

--- a/tests/tenant-session-pool.regression.test.ts
+++ b/tests/tenant-session-pool.regression.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Regression test — agent-context session pool leak / freeze.
+ *
+ * Root cause (confirmed on staging 2026-07): a tenant session slot could be acquired
+ * (TenantSessionMutex.currentSessions++) without a matching release when work failed on
+ * an un-guarded path (e.g. TenantsApi.getTenantAgent -> tenantAgent.initialize() throwing,
+ * or TenantSessionCoordinator.endAgentContextSession throwing before releaseSession()).
+ * Leaked slots accumulate until currentSessions pins at SESSION_LIMIT; the session mutex
+ * then never unlocks and every subsequent request waits SESSION_ACQUIRE_TIMEOUT and fails,
+ * until the process is restarted.
+ *
+ * Fix (patch @credo-ts+tenants+0.5.3+002): every acquired slot is released on every path
+ * (release moved into finally / release-on-initialize-failure / undo increment on failed lock).
+ *
+ * These tests exercise the REAL vendored TenantSessionMutex and guard the invariant the fix
+ * enforces: no matter how in-session work fails, the pool drains back to 0 and never wedges.
+ * (Full end-to-end validation is the staging load test + `leakcheck` — see
+ *  Debug/STAGE/SOLUTION-PLAN-session-pool-leak.md.)
+ */
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+import { TenantSessionMutex } from '@credo-ts/tenants/build/context/TenantSessionMutex'
+
+// Minimal logger stub matching the TsLogger surface the mutex uses.
+const logger: any = { debug: () => {}, info: () => {}, warn: () => {}, error: () => {}, trace: () => {} }
+
+// Mirrors the fixed acquire→work→release contract (release in finally).
+const withSession = async (mutex: any, work: () => Promise<void>): Promise<void> => {
+  await mutex.acquireSession()
+  try {
+    await work()
+  } finally {
+    mutex.releaseSession()
+  }
+}
+
+describe('tenant session pool — leak/freeze regression', () => {
+  it('drains to 0 and stays unlocked after many balanced acquire/release cycles', async () => {
+    const mutex: any = new TenantSessionMutex(logger, 100, 10000)
+    for (let i = 0; i < 500; i++) {
+      await mutex.acquireSession()
+      mutex.releaseSession()
+    }
+    expect(mutex.currentSessions).toBe(0)
+    expect(mutex.sessionMutex.isLocked()).toBe(false)
+  })
+
+  it('never wedges even when a large fraction of in-session work throws', async () => {
+    const mutex: any = new TenantSessionMutex(logger, 10, 2000)
+    for (let i = 0; i < 200; i++) {
+      try {
+        await withSession(mutex, async () => {
+          if (i % 3 === 0) throw new Error('simulated initialize()/callback failure')
+        })
+      } catch {
+        // expected for the failing third of iterations
+      }
+    }
+    // With release guaranteed in finally, the pool is fully drained despite ~1/3 failing.
+    expect(mutex.currentSessions).toBe(0)
+    expect(mutex.sessionMutex.isLocked()).toBe(false)
+    // And a fresh request still acquires immediately (pool not frozen).
+    await expect(mutex.acquireSession()).resolves.toBeUndefined()
+    mutex.releaseSession()
+  })
+
+  it('documents the failure mode: skipping release on error wedges the pool at the ceiling', async () => {
+    const mutex: any = new TenantSessionMutex(logger, 3, 300)
+    // Simulate the pre-fix leak: acquire, then work throws and release is SKIPPED.
+    for (let i = 0; i < 3; i++) {
+      try {
+        await mutex.acquireSession()
+        throw new Error('initialize failed — release skipped (pre-fix behaviour)')
+      } catch {
+        /* leaked slot */
+      }
+    }
+    // Counter pinned at the limit and the mutex is stuck locked.
+    expect(mutex.currentSessions).toBe(3)
+    expect(mutex.sessionMutex.isLocked()).toBe(true)
+    // A healthy request can no longer get in — it times out: the production freeze.
+    await expect(mutex.acquireSession()).rejects.toThrow(/Failed to acquire an agent context session/)
+  })
+})


### PR DESCRIPTION
fix(tenants): prevent agent-context session pool freeze (release slot on all paths)

## Problem
Under load the staging `ngotag-agent-controller` stops serving with
`Failed to acquire an agent context session within 10000ms`, and does **not** recover on its
own — it stays wedged for hours (observed ~18 h) until the ECS task is restarted, while the DB
is idle.

## Root cause (confirmed)
A tenant session slot (`TenantSessionMutex.currentSessions`) can be **acquired without a
matching release** on failure paths in `@credo-ts/tenants@0.5.3`:
- `TenantsApi.getTenantAgent` acquires the slot inside `getAgentContextForContextCorrelationId`,
  but `tenantAgent.initialize()` runs *before* `withTenantAgent`'s `try/finally`; if it throws,
  the slot is never released.
- `TenantSessionCoordinator.endAgentContextSession` calls `releaseSession()` outside a `finally`
  and throws-and-strands on an already-closed mapping.
- `TenantSessionMutex.acquireSession` increments before a post-increment lock that can reject.

Leaked slots accumulate until `currentSessions` pins at `SESSION_LIMIT` (100); the session mutex
then never unlocks and every request waits `SESSION_ACQUIRE_TIMEOUT` (10000 ms) and fails until
the process restarts. Verified with live CloudWatch data (acquires drop to 0 the instant the pool
hits its ceiling; freeze persists into idle; cleared only by restart) and reproduced against the
vendored algorithm.

## Fix
`patches/@credo-ts+tenants+0.5.3+002+session-release-exception-safe.patch` — guarantees the slot is
released on every path (no locking-algorithm change):
- `getTenantAgent`: release the slot if `initialize()` throws.
- `endAgentContextSession`: release in `finally`; on an unknown/closed mapping, warn + release
  instead of throwing.
- `acquireSession`: undo the increment if the post-increment lock times out.

Config baseline (`SESSION_LIMIT=100`, `SESSION_ACQUIRE_TIMEOUT=10000`) is unchanged — 100/10000 are
correct; the bug was the leak.

## Tests
`tests/tenant-session-pool.regression.test.ts` (runs against the real `TenantSessionMutex`):
balanced cycles drain to 0; the pool never wedges when a large fraction of in-session work throws;
and it documents the freeze (skipping release pins the counter and the next acquire times out).
All 3 pass.

## Verification / rollout
- [ ] `yarn build` + regression test green in CI
- [ ] Deploy to staging; reproduce the load burst
- [ ] `Debug/STAGE/ngotag-stage-readonly-investigation.sh leakcheck` — peak_sessions returns to
      baseline after load, acquires never stick at 0, no persistent "locked" in idle bins
- [ ] Break-glass restart no longer required

## Risk / rollback
Low — adds release paths only. Rollback: remove the patch file and reinstall.

_Note: the same code path exists in PROD; schedule the same patch there separately after staging
is validated._
