### PR TITLE
Sync deployment → pipeline-implementation (session-pool fix, instrumentation, did:ethr, ETH env)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -31,6 +31,10 @@ REDIS_CACHE_TTL_SECONDS=
 
 NATS_URL=nats://localhost:4333
 
+# Bearer token required to call POST /admin/log-level (runtime log-level toggle).
+# Leave unset to disable the admin endpoint entirely.
+ADMIN_TOKEN=
+
 # Specify Bcovrin test genesis
 BCOVRIN_TEST_GENESIS=`{"reqSignature":{},"txn":{"data":{"data":{"alias":"Node1","blskey":"4N8aUNHSgjQVgkpm8nhNEfDf6txHznoYREg9kirmJrkivgL4oSEimFF6nsQ6M41QvhM2Z33nves5vfSn9n1UwNFJBYtWVnHYMATn76vLuL3zU88KyeAYcHfsih3He6UHcXDxcaecHVz6jhCYz1P2UZn2bDVruL5wXpehgBfBaLKm3Ba","blskey_pop":"RahHYiCvoNCtPTrVtP7nMC5eTYrsUA8WjXbdhNc8debh1agE9bGiJxWBXYNFbnJXoXhWFMvyqhqhRoq737YQemH5ik9oL7R4NTTCz2LEZhkgLJzB3QRQqJyBNyv7acbdHrAT8nQ9UkLbaVL9NBpnWXBTw4LEMePaSHEw66RzPNdAX1","client_ip":"138.197.138.255","client_port":9702,"node_ip":"138.197.138.255","node_port":9701,"services":["VALIDATOR"]},"dest":"Gw6pDLhcBcoQesN72qfotTgFa7cbuqZpkX3Xo6pLhPhv"},"metadata":{"from":"Th7MpTaRZVRYnPiabds81Y"},"type":"0"},"txnMetadata":{"seqNo":1,"txnId":"fea82e10e894419fe2bea7d96296a6d46f50f93f9eeda954ec461b2ed2950b62"},"ver":"1"}
 {"reqSignature":{},"txn":{"data":{"data":{"alias":"Node2","blskey":"37rAPpXVoxzKhz7d9gkUe52XuXryuLXoM6P6LbWDB7LSbG62Lsb33sfG7zqS8TK1MXwuCHj1FKNzVpsnafmqLG1vXN88rt38mNFs9TENzm4QHdBzsvCuoBnPH7rpYYDo9DZNJePaDvRvqJKByCabubJz3XXKbEeshzpz4Ma5QYpJqjk","blskey_pop":"Qr658mWZ2YC8JXGXwMDQTzuZCWF7NK9EwxphGmcBvCh6ybUuLxbG65nsX4JvD4SPNtkJ2w9ug1yLTj6fgmuDg41TgECXjLCij3RMsV8CwewBVgVN67wsA45DFWvqvLtu4rjNnE9JbdFTc1Z4WCPA3Xan44K1HoHAq9EVeaRYs8zoF5","client_ip":"138.197.138.255","client_port":9704,"node_ip":"138.197.138.255","node_port":9703,"services":["VALIDATOR"]},"dest":"8ECVSk179mjsjKRLWiQtssMLgp6EPhWXtaYyStWPSGAb"},"metadata":{"from":"EbP4aYNeTHL6q385GuVpRV"},"type":"0"},"txnMetadata":{"seqNo":2,"txnId":"1ac8aece2a18ced660fef8694b61aac3af08ba875ce3026a160acbc3a3af35fc"},"ver":"1"}

--- a/.env.sample
+++ b/.env.sample
@@ -44,8 +44,16 @@ REDIS_CACHE_TTL_SECONDS=
 
 NATS_URL=nats://localhost:4333
 
+# Master switch for the latency debug instrumentation. Default false: the agent
+# runs stock (no inbound middleware, no instrumented tenant wrapper / wallet-open
+# probe, no gauges, no admin endpoint) and emitStructured() is a no-op. Set true
+# to enable instrumentation; verbosity is then controlled at runtime via
+# /admin/log-level.
+INSTRUMENTATION_ENABLED=false
+
 # Bearer token required to call POST /admin/log-level (runtime log-level toggle).
-# Leave unset to disable the admin endpoint entirely.
+# Only used when INSTRUMENTATION_ENABLED=true; the endpoint is still mounted in
+# that case, but requests are rejected with 503 when ADMIN_TOKEN is unset.
 ADMIN_TOKEN=
 
 # ---------------------------------------------------------------------------

--- a/.env.sample
+++ b/.env.sample
@@ -26,6 +26,18 @@ windowMs=
 maxRateLimit=
 # Specify Did contract address
 DID_CONTRACT_ADDRESS=
+# Specify Ethereum network name
+ETHEREUM_NETWORK_NAME=
+# Specify Ethereum chain id
+ETHEREUM_CHAIN_ID=
+# Specify Ethereum network RPC URL
+ETHEREUM_NETWORK_RPC_URL=
+# Specify Ethereum DID registry contract address
+ETHEREUM_DID_REGISTRY_CONTRACT_ADDRESS=
+# Specify Ethereum Schema Manager contract address
+ETHEREUM_SCHEMA_MANAGER_CONTRACT_ADDRESS=
+# Specify Ethereum module RPC URL
+ETHEREUM_RPC_URL=
 REDIS_URL=
 REDIS_CACHE_TTL_SECONDS=
 

--- a/.env.sample
+++ b/.env.sample
@@ -30,13 +30,11 @@ DID_CONTRACT_ADDRESS=
 ETHEREUM_NETWORK_NAME=
 # Specify Ethereum chain id
 ETHEREUM_CHAIN_ID=
-# Specify Ethereum network RPC URL
-ETHEREUM_NETWORK_RPC_URL=
 # Specify Ethereum DID registry contract address
 ETHEREUM_DID_REGISTRY_CONTRACT_ADDRESS=
 # Specify Ethereum Schema Manager contract address
 ETHEREUM_SCHEMA_MANAGER_CONTRACT_ADDRESS=
-# Specify Ethereum module RPC URL
+# Specify Ethereum RPC URL
 ETHEREUM_RPC_URL=
 REDIS_URL=
 REDIS_CACHE_TTL_SECONDS=

--- a/.env.sample
+++ b/.env.sample
@@ -7,6 +7,9 @@ IDLE_TIMEOUT=
 #Specify max number 2147483647
 SESSION_ACQUIRE_TIMEOUT=
 SESSION_LIMIT=
+# Maximum number of JSON-LD context documents held in the in-process LRU cache.
+# Cached entries survive Redis outages and are served with zero network cost.
+# Default: 500
 INMEMORY_LRU_CACHE_LIMIT=
 # Specify BCovrin Register url
 BCOVRIN_REGISTER_URL=
@@ -44,6 +47,34 @@ NATS_URL=nats://localhost:4333
 # Bearer token required to call POST /admin/log-level (runtime log-level toggle).
 # Leave unset to disable the admin endpoint entirely.
 ADMIN_TOKEN=
+
+# ---------------------------------------------------------------------------
+# JSON-LD document loader (CachedDocumentLoader)
+# ---------------------------------------------------------------------------
+
+# Hard timeout (ms) for fetching allowlisted HTTP/HTTPS JSON-LD context documents.
+# Applies to the live-fetch path after static-map, LRU, and Redis all miss.
+# Default: 3000
+JSONLD_FETCH_TIMEOUT_MS=
+
+# Hard timeout (ms) for resolving did: URLs via DidResolverService.
+# Must be larger than JSONLD_FETCH_TIMEOUT_MS because a Redis commandTimeout (~3 s)
+# can be consumed before RPC resolution starts; 3 s here guarantees failure under
+# Redis degradation.
+# Default: 12000
+DID_RESOLVE_TIMEOUT_MS=
+
+# Maximum size (bytes) of a JSON-LD context document that will be written to the
+# LRU and Redis caches. Documents larger than this are fetched live every time.
+# Default: 262144 (256 KiB)
+JSONLD_MAX_DOC_BYTES=
+
+# Comma-separated list of additional hostnames allowed for live JSON-LD context
+# fetches, beyond the built-in set (www.w3.org, w3.org, w3id.org,
+# identity.foundation, and the host derived from SERVER_URL).
+# Example: ALLOWED_CONTEXT_HOSTS=schemas.example.com,ctx.example.org
+# Default: (empty — only built-in hosts are allowed)
+ALLOWED_CONTEXT_HOSTS=
 
 # Specify Bcovrin test genesis
 BCOVRIN_TEST_GENESIS=`{"reqSignature":{},"txn":{"data":{"data":{"alias":"Node1","blskey":"4N8aUNHSgjQVgkpm8nhNEfDf6txHznoYREg9kirmJrkivgL4oSEimFF6nsQ6M41QvhM2Z33nves5vfSn9n1UwNFJBYtWVnHYMATn76vLuL3zU88KyeAYcHfsih3He6UHcXDxcaecHVz6jhCYz1P2UZn2bDVruL5wXpehgBfBaLKm3Ba","blskey_pop":"RahHYiCvoNCtPTrVtP7nMC5eTYrsUA8WjXbdhNc8debh1agE9bGiJxWBXYNFbnJXoXhWFMvyqhqhRoq737YQemH5ik9oL7R4NTTCz2LEZhkgLJzB3QRQqJyBNyv7acbdHrAT8nQ9UkLbaVL9NBpnWXBTw4LEMePaSHEw66RzPNdAX1","client_ip":"138.197.138.255","client_port":9702,"node_ip":"138.197.138.255","node_port":9701,"services":["VALIDATOR"]},"dest":"Gw6pDLhcBcoQesN72qfotTgFa7cbuqZpkX3Xo6pLhPhv"},"metadata":{"from":"Th7MpTaRZVRYnPiabds81Y"},"type":"0"},"txnMetadata":{"seqNo":1,"txnId":"fea82e10e894419fe2bea7d96296a6d46f50f93f9eeda954ec461b2ed2950b62"},"ver":"1"}

--- a/patches/@credo-ts+tenants+0.5.3+002+session-release-exception-safe.patch
+++ b/patches/@credo-ts+tenants+0.5.3+002+session-release-exception-safe.patch
@@ -1,0 +1,99 @@
+diff --git a/node_modules/@credo-ts/tenants/build/TenantsApi.js b/node_modules/@credo-ts/tenants/build/TenantsApi.js
+--- a/node_modules/@credo-ts/tenants/build/TenantsApi.js
++++ b/node_modules/@credo-ts/tenants/build/TenantsApi.js
+@@ -29,7 +29,20 @@
+         const tenantContext = await this.agentContextProvider.getAgentContextForContextCorrelationId(tenantId);
+         this.logger.trace(`Got tenant context for tenant '${tenantId}'`);
+         const tenantAgent = new TenantAgent_1.TenantAgent(tenantContext);
+-        await tenantAgent.initialize();
++        try {
++            await tenantAgent.initialize();
++        }
++        catch (error) {
++            // PATCH(+002): the session slot was already acquired inside
++            // getAgentContextForContextCorrelationId. If initialize() fails, withTenantAgent's
++            // finally is never reached, so we must release the slot here or the global session
++            // counter leaks and the pool wedges at SESSION_LIMIT.
++            try {
++                await tenantAgent.endSession();
++            }
++            catch (_) { /* best-effort release */ }
++            throw error;
++        }
+         this.logger.trace(`Initializing tenant agent for tenant '${tenantId}'`);
+         return tenantAgent;
+     }
+diff --git a/node_modules/@credo-ts/tenants/build/context/TenantSessionMutex.js b/node_modules/@credo-ts/tenants/build/context/TenantSessionMutex.js
+--- a/node_modules/@credo-ts/tenants/build/context/TenantSessionMutex.js
++++ b/node_modules/@credo-ts/tenants/build/context/TenantSessionMutex.js
+@@ -54,7 +54,15 @@
+         // If we reached the limit we should lock the session mutex
+         if (this.currentSessions >= this.maxSessions) {
+             this.logger.debug(`Reached max number of sessions ${this.maxSessions}, locking mutex`);
+-            await this.sessionMutex.acquire();
++            try {
++                await this.sessionMutex.acquire();
++            }
++            catch (error) {
++                // PATCH(+002): the post-increment lock timed out. currentSessions was already
++                // incremented above, so undo it before propagating or the slot leaks permanently.
++                this.currentSessions--;
++                throw error;
++            }
+         }
+         this.logger.debug(`Acquired tenant session (${this.currentSessions} / ${this.maxSessions})`);
+     }
+diff --git a/node_modules/@credo-ts/tenants/build/context/TenantSessionCoordinator.js b/node_modules/@credo-ts/tenants/build/context/TenantSessionCoordinator.js
+--- a/node_modules/@credo-ts/tenants/build/context/TenantSessionCoordinator.js
++++ b/node_modules/@credo-ts/tenants/build/context/TenantSessionCoordinator.js
+@@ -118,24 +118,33 @@
+             this.logger.debug('Ending session for root agent context. Not disposing dependency manager');
+             return;
+         }
+-        // This should not happen
+-        if (!hasTenantSessionMapping) {
+-            this.logger.error(`Unknown agent context with contextCorrelationId '${agentContext.contextCorrelationId}'.  Cannot end session`);
+-            throw new core_1.CredoError(`Unknown agent context with contextCorrelationId '${agentContext.contextCorrelationId}'. Cannot end session`);
+-        }
+-        await this.mutexForTenant(agentContext.contextCorrelationId).runExclusive(async () => {
+-            this.logger.debug(`Acquired lock for tenant '${agentContext.contextCorrelationId}' to end session context`);
+-            const tenantSessions = this.getTenantSessionsMapping(agentContext.contextCorrelationId);
+-            // TODO: check if session count is already 0
+-            tenantSessions.sessionCount--;
+-            this.logger.debug(`Decreased agent context session count for tenant '${agentContext.contextCorrelationId}' to ${tenantSessions.sessionCount}`);
+-            if (tenantSessions.sessionCount <= 0 && tenantSessions.agentContext) {
+-                await this.closeAgentContext(tenantSessions.agentContext);
+-                delete this.tenantAgentContextMapping[agentContext.contextCorrelationId];
++        // PATCH(+002): a session slot was acquired for this context, so it MUST be released on
++        // every exit path. Previously an early throw (unknown mapping) or a rejection from the
++        // runExclusive block below skipped releaseSession(), leaking the slot and eventually
++        // wedging the pool at SESSION_LIMIT. Release now runs in a finally, and an
++        // already-closed mapping no longer throws-and-strands the slot.
++        try {
++            // This should not happen (mapping already closed by a concurrent sibling).
++            if (!hasTenantSessionMapping) {
++                this.logger.warn(`Unknown agent context with contextCorrelationId '${agentContext.contextCorrelationId}' on endSession; releasing session slot anyway`);
++                return;
+             }
+-        });
+-        // Release a session so new sessions can be acquired
+-        this.sessionMutex.releaseSession();
++            await this.mutexForTenant(agentContext.contextCorrelationId).runExclusive(async () => {
++                this.logger.debug(`Acquired lock for tenant '${agentContext.contextCorrelationId}' to end session context`);
++                const tenantSessions = this.getTenantSessionsMapping(agentContext.contextCorrelationId);
++                // TODO: check if session count is already 0
++                tenantSessions.sessionCount--;
++                this.logger.debug(`Decreased agent context session count for tenant '${agentContext.contextCorrelationId}' to ${tenantSessions.sessionCount}`);
++                if (tenantSessions.sessionCount <= 0 && tenantSessions.agentContext) {
++                    await this.closeAgentContext(tenantSessions.agentContext);
++                    delete this.tenantAgentContextMapping[agentContext.contextCorrelationId];
++                }
++            });
++        }
++        finally {
++            // Release a session so new sessions can be acquired
++            this.sessionMutex.releaseSession();
++        }
+     }
+     hasTenantSessionMapping(tenantId) {
+         return this.tenantAgentContextMapping[tenantId] !== undefined;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,7 +44,6 @@ interface Parsed {
   fileServerToken?: string
   ethereumNetworkName?: string
   ethereumChainId?: string
-  ethereumNetworkRpcUrl?: string
   ethereumRegistry?: string
   ethereumSchemaManagerContractAddress?: string
   ethereumRpcUrl?: string
@@ -121,10 +120,6 @@ async function parseArguments(): Promise<Parsed> {
       demandOption: false,
     })
     .option('ethereum-chain-id', {
-      string: true,
-      demandOption: false,
-    })
-    .option('ethereum-network-rpc-url', {
       string: true,
       demandOption: false,
     })
@@ -299,7 +294,6 @@ export async function runCliServer() {
     fileServerToken: parsed['fileServerToken'],
     ethereumNetworkName: parsed['ethereumNetworkName'] || parsed['chainName'],
     ethereumChainId: parsed['ethereumChainId'] || parsed['chainId'],
-    ethereumNetworkRpcUrl: parsed['ethereumNetworkRpcUrl'],
     ethereumRegistry: parsed['ethereumRegistry'] || parsed['registry'],
     ethereumSchemaManagerContractAddress: parsed['ethereumSchemaManagerContractAddress'],
     ethereumRpcUrl: parsed['ethereumRpcUrl'],

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -42,6 +42,12 @@ interface Parsed {
   rpcUrl?: string
   fileServerUrl?: string
   fileServerToken?: string
+  ethereumNetworkName?: string
+  ethereumChainId?: string
+  ethereumNetworkRpcUrl?: string
+  ethereumRegistry?: string
+  ethereumSchemaManagerContractAddress?: string
+  ethereumRpcUrl?: string
   chainId?: string
   chainName?: string
   registry?: string
@@ -98,7 +104,7 @@ async function parseArguments(): Promise<Parsed> {
       string: true,
       demandOption: true,
     })
-     .option('chainId', {
+    .option('chainId', {
       string: true,
       demandOption: false,
     })
@@ -107,6 +113,30 @@ async function parseArguments(): Promise<Parsed> {
       demandOption: false,
     })
     .option('registry', {
+      string: true,
+      demandOption: false,
+    })
+    .option('ethereum-network-name', {
+      string: true,
+      demandOption: false,
+    })
+    .option('ethereum-chain-id', {
+      string: true,
+      demandOption: false,
+    })
+    .option('ethereum-network-rpc-url', {
+      string: true,
+      demandOption: false,
+    })
+    .option('ethereum-registry', {
+      string: true,
+      demandOption: false,
+    })
+    .option('ethereum-schema-manager-contract-address', {
+      string: true,
+      demandOption: false,
+    })
+    .option('ethereum-rpc-url', {
       string: true,
       demandOption: false,
     })
@@ -267,8 +297,11 @@ export async function runCliServer() {
     rpcUrl: parsed['rpcUrl'],
     fileServerUrl: parsed['fileServerUrl'],
     fileServerToken: parsed['fileServerToken'],
-    chainId: parsed['chainId'],
-    name: parsed['chainName'],
-    registry: parsed['registry'],
+    ethereumNetworkName: parsed['ethereumNetworkName'] || parsed['chainName'],
+    ethereumChainId: parsed['ethereumChainId'] || parsed['chainId'],
+    ethereumNetworkRpcUrl: parsed['ethereumNetworkRpcUrl'],
+    ethereumRegistry: parsed['ethereumRegistry'] || parsed['registry'],
+    ethereumSchemaManagerContractAddress: parsed['ethereumSchemaManagerContractAddress'],
+    ethereumRpcUrl: parsed['ethereumRpcUrl'],
   } as unknown as AriesRestConfig)
 }

--- a/src/cliAgent.ts
+++ b/src/cliAgent.ts
@@ -454,7 +454,7 @@ export async function runRestAgent(restConfig: AriesRestConfig) {
             ? tryExtractFromJwe(raw)
             : { recipientKeyShort: '', jweFp: '' }
           const spanId = makeSpanId()
-          emitStructured(LogLevel.info, {
+          emitStructured(LogLevel.trace, {
             hop: 'controller.http.inbound.received',
             span_id: spanId,
             jwe_fp: jweFp,
@@ -474,7 +474,7 @@ export async function runRestAgent(restConfig: AriesRestConfig) {
 
   await agent.initialize()
 
-  emitStructured(LogLevel.info, {
+  emitStructured(LogLevel.trace, {
     hop: 'controller.config.dump',
     flow: 'lifecycle',
     notes: 'effective config at startup',

--- a/src/cliAgent.ts
+++ b/src/cliAgent.ts
@@ -450,22 +450,21 @@ export async function runRestAgent(restConfig: AriesRestConfig) {
       transport.app.use((req: any, res: any, next: any) => {
         if (req.method === 'POST') {
           const raw: string = typeof req.body === 'string' ? req.body : ''
-          const { recipientKeyShort, outerMsgId } = raw
+          const { recipientKeyShort, jweFp } = raw
             ? tryExtractFromJwe(raw)
-            : { recipientKeyShort: '', outerMsgId: '' }
+            : { recipientKeyShort: '', jweFp: '' }
           const spanId = makeSpanId()
           emitStructured(LogLevel.info, {
             hop: 'controller.http.inbound.received',
             span_id: spanId,
-            outer_msg_id: outerMsgId,
+            jwe_fp: jweFp,
             recipient_key_short: recipientKeyShort,
             content_length: req.headers['content-length'] ? Number(req.headers['content-length']) : undefined,
-            notes: outerMsgId ? undefined : 'outer_msg_id not in JWE protected header — timing join only',
           })
           res.locals.__dbg_span = spanId
           res.locals.__dbg_start = monoNow()
-          // Thread outer_msg_id through Credo's async chain so event handlers can read it.
-          return requestContext.run({ outerMsgId }, () => next())
+          // Thread JWE fingerprint through Credo's async chain so event handlers can read it.
+          return requestContext.run({ jweFp }, () => next())
         }
         next()
       })

--- a/src/cliAgent.ts
+++ b/src/cliAgent.ts
@@ -60,7 +60,7 @@ import { setupServer } from './server'
 import { buildCachedDocumentLoader } from './utils/CachedDocumentLoader'
 import { RedisCache } from './utils/RedisCache'
 import { TsLogger } from './utils/logger'
-import { emitStructured, makeSpanId, monoNow, tryExtractFromJwe } from './utils/StructuredLogger'
+import { emitStructured, isInstrumentationEnabled, makeSpanId, monoNow, tryExtractFromJwe } from './utils/StructuredLogger'
 import { startGauges } from './instrumentation/gauges'
 import { requestContext } from './instrumentation/requestContext'
 
@@ -484,7 +484,7 @@ export async function runRestAgent(restConfig: AriesRestConfig) {
     // Add instrumentation middleware to the HTTP inbound transport's express app.
     // express.text() body parser is added in the transport constructor so req.body is
     // available as a string when our middleware fires.
-    if (inboundTransport.transport === 'http' && transport.app) {
+    if (isInstrumentationEnabled() && inboundTransport.transport === 'http' && transport.app) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       transport.app.use((req: any, res: any, next: any) => {
         if (req.method === 'POST') {
@@ -524,7 +524,7 @@ export async function runRestAgent(restConfig: AriesRestConfig) {
     admin_port: adminPort,
   })
 
-  startGauges()
+  if (isInstrumentationEnabled()) startGauges()
 
   let token: string = ''
   const genericRecord = await agent.genericRecords.getAll()

--- a/src/cliAgent.ts
+++ b/src/cliAgent.ts
@@ -106,6 +106,15 @@ export interface AriesRestConfig {
   rpcUrl?: string
   fileServerUrl?: string
   fileServerToken?: string
+  ethereumNetworkName?: string
+  ethereumChainId?: string | number
+  ethereumNetworkRpcUrl?: string
+  ethereumRegistry?: string
+  ethereumSchemaManagerContractAddress?: string
+  ethereumRpcUrl?: string
+  chainId?: string | number
+  name?: string
+  registry?: string
   walletScheme?: AskarMultiWalletDatabaseScheme
   schemaFileServerURL?: string
 }
@@ -120,6 +129,15 @@ export async function readRestConfig(path: string) {
 export type RestMultiTenantAgentModules = Awaited<ReturnType<typeof getWithTenantModules>>
 
 export type RestAgentModules = Awaited<ReturnType<typeof getModules>>
+
+interface EthereumModuleEnvironmentConfig {
+  ethereumNetworkName?: string
+  ethereumChainId?: string | number
+  ethereumNetworkRpcUrl?: string
+  ethereumRegistry?: string
+  ethereumSchemaManagerContractAddress?: string
+  ethereumRpcUrl?: string
+}
 
 const initializeCache = (logger: TsLogger) => {
   const redisUrl = process.env.REDIS_URL
@@ -147,8 +165,22 @@ const getModules = (
   autoAcceptCredentials: AutoAcceptCredential,
   autoAcceptProofs: AutoAcceptProof,
   walletScheme: AskarMultiWalletDatabaseScheme,
-  logger: TsLogger
+  logger: TsLogger,
+  ethereumModuleConfig: EthereumModuleEnvironmentConfig = {}
 ) => {
+  const ethereumNetworkName = ethereumModuleConfig.ethereumNetworkName || process.env.ETHEREUM_NETWORK_NAME
+  const ethereumChainId = Number(ethereumModuleConfig.ethereumChainId || process.env.ETHEREUM_CHAIN_ID)
+  const ethereumNetworkRpcUrl =
+    ethereumModuleConfig.ethereumNetworkRpcUrl || process.env.ETHEREUM_NETWORK_RPC_URL
+  const ethereumRegistry =
+    ethereumModuleConfig.ethereumRegistry ||
+    process.env.ETHEREUM_DID_REGISTRY_CONTRACT_ADDRESS ||
+    process.env.ETHEREUM_REGISTRY
+  const ethereumSchemaManagerContractAddress =
+    ethereumModuleConfig.ethereumSchemaManagerContractAddress ||
+    process.env.ETHEREUM_SCHEMA_MANAGER_CONTRACT_ADDRESS
+  const ethereumRpcUrl = ethereumModuleConfig.ethereumRpcUrl || process.env.ETHEREUM_RPC_URL
+
   const legacyIndyCredentialFormat = new LegacyIndyCredentialFormatService()
   const legacyIndyProofFormat = new LegacyIndyProofFormatService()
   const jsonLdCredentialFormatService = new JsonLdCredentialFormatService()
@@ -238,17 +270,17 @@ const getModules = (
       config: {
         networks: [
           {
-            name: 'sepolia',
-            chainId: 11155111,
-            rpcUrl: 'https://ethereum-sepolia-rpc.publicnode.com',
-            registry: '0x485cFb9cdB84c0a5AfE69b75E2e79497Fc2256Fc',
+            name: ethereumNetworkName as string,
+            chainId: ethereumChainId,
+            rpcUrl: ethereumNetworkRpcUrl as string,
+            registry: ethereumRegistry as string,
           },
         ],
       },
-      schemaManagerContractAddress: '0xa95ACF3119791F65b2192267836df9A472785c15',
-      serverUrl: 'https://dev-schema.ngotag.com',
-      fileServerToken: 'ACCESS-TOKEN',
-      rpcUrl: 'https://eth-sepolia.g.alchemy.com/v2/API-KEY',
+      schemaManagerContractAddress: ethereumSchemaManagerContractAddress as string,
+      serverUrl: fileServerUrl ? fileServerUrl : (process.env.SERVER_URL as string),
+      fileServerToken: fileServerToken ? fileServerToken : (process.env.FILE_SERVER_TOKEN as string),
+      rpcUrl: ethereumRpcUrl as string,
     }),
   }
 }
@@ -265,7 +297,8 @@ const getWithTenantModules = (
   autoAcceptCredentials: AutoAcceptCredential,
   autoAcceptProofs: AutoAcceptProof,
   walletScheme: AskarMultiWalletDatabaseScheme,
-  logger: TsLogger
+  logger: TsLogger,
+  ethereumModuleConfig: EthereumModuleEnvironmentConfig = {}
 ) => {
   const modules = getModules(
     networkConfig,
@@ -278,7 +311,8 @@ const getWithTenantModules = (
     autoAcceptCredentials,
     autoAcceptProofs,
     walletScheme,
-    logger
+    logger,
+    ethereumModuleConfig
   )
   return {
     tenants: new TenantsModule<typeof modules>({
@@ -320,6 +354,15 @@ export async function runRestAgent(restConfig: AriesRestConfig) {
     fileServerUrl,
     rpcUrl,
     schemaManagerContractAddress,
+    ethereumNetworkName,
+    ethereumChainId,
+    ethereumNetworkRpcUrl,
+    ethereumRegistry,
+    ethereumSchemaManagerContractAddress,
+    ethereumRpcUrl,
+    chainId,
+    name,
+    registry,
     walletConfig,
     autoAcceptConnections,
     autoAcceptCredentials,
@@ -399,6 +442,15 @@ export async function runRestAgent(restConfig: AriesRestConfig) {
     ]
   }
 
+  const ethereumModuleConfig = {
+    ethereumNetworkName: ethereumNetworkName || name,
+    ethereumChainId: ethereumChainId || chainId,
+    ethereumNetworkRpcUrl,
+    ethereumRegistry: ethereumRegistry || registry,
+    ethereumSchemaManagerContractAddress,
+    ethereumRpcUrl,
+  }
+
   const tenantModule = await getWithTenantModules(
     networkConfig,
     didRegistryContractAddress || '',
@@ -410,7 +462,8 @@ export async function runRestAgent(restConfig: AriesRestConfig) {
     autoAcceptCredentials || AutoAcceptCredential.Always,
     autoAcceptProofs || AutoAcceptProof.ContentApproved,
     walletScheme || AskarMultiWalletDatabaseScheme.ProfilePerWallet,
-    logger
+    logger,
+    ethereumModuleConfig
   )
   const modules = getModules(
     networkConfig,
@@ -423,7 +476,8 @@ export async function runRestAgent(restConfig: AriesRestConfig) {
     autoAcceptCredentials || AutoAcceptCredential.Always,
     autoAcceptProofs || AutoAcceptProof.ContentApproved,
     walletScheme || AskarMultiWalletDatabaseScheme.ProfilePerWallet,
-    logger
+    logger,
+    ethereumModuleConfig
   )
   const agent = new Agent({
     config: agentConfig,

--- a/src/cliAgent.ts
+++ b/src/cliAgent.ts
@@ -111,9 +111,6 @@ export interface AriesRestConfig {
   ethereumRegistry?: string
   ethereumSchemaManagerContractAddress?: string
   ethereumRpcUrl?: string
-  chainId?: string | number
-  name?: string
-  registry?: string
   walletScheme?: AskarMultiWalletDatabaseScheme
   schemaFileServerURL?: string
 }
@@ -169,10 +166,7 @@ const getModules = (
   const ethereumNetworkName = ethereumModuleConfig.ethereumNetworkName || process.env.ETHEREUM_NETWORK_NAME
   const ethereumChainId = Number(ethereumModuleConfig.ethereumChainId || process.env.ETHEREUM_CHAIN_ID)
   const ethereumRpcUrl = ethereumModuleConfig.ethereumRpcUrl || process.env.ETHEREUM_RPC_URL
-  const ethereumRegistry =
-    ethereumModuleConfig.ethereumRegistry ||
-    process.env.ETHEREUM_DID_REGISTRY_CONTRACT_ADDRESS ||
-    process.env.ETHEREUM_REGISTRY
+  const ethereumRegistry = ethereumModuleConfig.ethereumRegistry || process.env.ETHEREUM_DID_REGISTRY_CONTRACT_ADDRESS
   const ethereumSchemaManagerContractAddress =
     ethereumModuleConfig.ethereumSchemaManagerContractAddress ||
     process.env.ETHEREUM_SCHEMA_MANAGER_CONTRACT_ADDRESS
@@ -355,9 +349,6 @@ export async function runRestAgent(restConfig: AriesRestConfig) {
     ethereumRegistry,
     ethereumSchemaManagerContractAddress,
     ethereumRpcUrl,
-    chainId,
-    name,
-    registry,
     walletConfig,
     autoAcceptConnections,
     autoAcceptCredentials,
@@ -438,9 +429,9 @@ export async function runRestAgent(restConfig: AriesRestConfig) {
   }
 
   const ethereumModuleConfig = {
-    ethereumNetworkName: ethereumNetworkName || name,
-    ethereumChainId: ethereumChainId || chainId,
-    ethereumRegistry: ethereumRegistry || registry,
+    ethereumNetworkName,
+    ethereumChainId,
+    ethereumRegistry,
     ethereumSchemaManagerContractAddress,
     ethereumRpcUrl,
   }

--- a/src/cliAgent.ts
+++ b/src/cliAgent.ts
@@ -108,7 +108,6 @@ export interface AriesRestConfig {
   fileServerToken?: string
   ethereumNetworkName?: string
   ethereumChainId?: string | number
-  ethereumNetworkRpcUrl?: string
   ethereumRegistry?: string
   ethereumSchemaManagerContractAddress?: string
   ethereumRpcUrl?: string
@@ -133,7 +132,6 @@ export type RestAgentModules = Awaited<ReturnType<typeof getModules>>
 interface EthereumModuleEnvironmentConfig {
   ethereumNetworkName?: string
   ethereumChainId?: string | number
-  ethereumNetworkRpcUrl?: string
   ethereumRegistry?: string
   ethereumSchemaManagerContractAddress?: string
   ethereumRpcUrl?: string
@@ -170,8 +168,7 @@ const getModules = (
 ) => {
   const ethereumNetworkName = ethereumModuleConfig.ethereumNetworkName || process.env.ETHEREUM_NETWORK_NAME
   const ethereumChainId = Number(ethereumModuleConfig.ethereumChainId || process.env.ETHEREUM_CHAIN_ID)
-  const ethereumNetworkRpcUrl =
-    ethereumModuleConfig.ethereumNetworkRpcUrl || process.env.ETHEREUM_NETWORK_RPC_URL
+  const ethereumRpcUrl = ethereumModuleConfig.ethereumRpcUrl || process.env.ETHEREUM_RPC_URL
   const ethereumRegistry =
     ethereumModuleConfig.ethereumRegistry ||
     process.env.ETHEREUM_DID_REGISTRY_CONTRACT_ADDRESS ||
@@ -179,7 +176,6 @@ const getModules = (
   const ethereumSchemaManagerContractAddress =
     ethereumModuleConfig.ethereumSchemaManagerContractAddress ||
     process.env.ETHEREUM_SCHEMA_MANAGER_CONTRACT_ADDRESS
-  const ethereumRpcUrl = ethereumModuleConfig.ethereumRpcUrl || process.env.ETHEREUM_RPC_URL
 
   const legacyIndyCredentialFormat = new LegacyIndyCredentialFormatService()
   const legacyIndyProofFormat = new LegacyIndyProofFormatService()
@@ -272,7 +268,7 @@ const getModules = (
           {
             name: ethereumNetworkName as string,
             chainId: ethereumChainId,
-            rpcUrl: ethereumNetworkRpcUrl as string,
+            rpcUrl: ethereumRpcUrl as string,
             registry: ethereumRegistry as string,
           },
         ],
@@ -356,7 +352,6 @@ export async function runRestAgent(restConfig: AriesRestConfig) {
     schemaManagerContractAddress,
     ethereumNetworkName,
     ethereumChainId,
-    ethereumNetworkRpcUrl,
     ethereumRegistry,
     ethereumSchemaManagerContractAddress,
     ethereumRpcUrl,
@@ -445,7 +440,6 @@ export async function runRestAgent(restConfig: AriesRestConfig) {
   const ethereumModuleConfig = {
     ethereumNetworkName: ethereumNetworkName || name,
     ethereumChainId: ethereumChainId || chainId,
-    ethereumNetworkRpcUrl,
     ethereumRegistry: ethereumRegistry || registry,
     ethereumSchemaManagerContractAddress,
     ethereumRpcUrl,

--- a/src/cliAgent.ts
+++ b/src/cliAgent.ts
@@ -60,6 +60,9 @@ import { setupServer } from './server'
 import { buildCachedDocumentLoader } from './utils/CachedDocumentLoader'
 import { RedisCache } from './utils/RedisCache'
 import { TsLogger } from './utils/logger'
+import { emitStructured, makeSpanId, monoNow, tryExtractFromJwe } from './utils/StructuredLogger'
+import { startGauges } from './instrumentation/gauges'
+import { requestContext } from './instrumentation/requestContext'
 
 export type Transports = 'ws' | 'http'
 export type InboundTransport = {
@@ -437,10 +440,53 @@ export async function runRestAgent(restConfig: AriesRestConfig) {
   // Register inbound transports
   for (const inboundTransport of inboundTransports) {
     const InboundTransport = inboundTransportMapping[inboundTransport.transport]
-    agent.registerInboundTransport(new InboundTransport({ port: inboundTransport.port }))
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const transport: any = new (InboundTransport as any)({ port: inboundTransport.port })
+    // Add instrumentation middleware to the HTTP inbound transport's express app.
+    // express.text() body parser is added in the transport constructor so req.body is
+    // available as a string when our middleware fires.
+    if (inboundTransport.transport === 'http' && transport.app) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      transport.app.use((req: any, res: any, next: any) => {
+        if (req.method === 'POST') {
+          const raw: string = typeof req.body === 'string' ? req.body : ''
+          const { recipientKeyShort, outerMsgId } = raw
+            ? tryExtractFromJwe(raw)
+            : { recipientKeyShort: '', outerMsgId: '' }
+          const spanId = makeSpanId()
+          emitStructured(LogLevel.info, {
+            hop: 'controller.http.inbound.received',
+            span_id: spanId,
+            outer_msg_id: outerMsgId,
+            recipient_key_short: recipientKeyShort,
+            content_length: req.headers['content-length'] ? Number(req.headers['content-length']) : undefined,
+            notes: outerMsgId ? undefined : 'outer_msg_id not in JWE protected header — timing join only',
+          })
+          res.locals.__dbg_span = spanId
+          res.locals.__dbg_start = monoNow()
+          // Thread outer_msg_id through Credo's async chain so event handlers can read it.
+          return requestContext.run({ outerMsgId }, () => next())
+        }
+        next()
+      })
+    }
+    agent.registerInboundTransport(transport)
   }
 
   await agent.initialize()
+
+  emitStructured(LogLevel.info, {
+    hop: 'controller.config.dump',
+    flow: 'lifecycle',
+    notes: 'effective config at startup',
+    session_limit: Number(process.env.SESSION_LIMIT) || 10,
+    session_acquire_timeout_ms: Number(process.env.SESSION_ACQUIRE_TIMEOUT) || 10000,
+    wallet_scheme: walletScheme || AskarMultiWalletDatabaseScheme.ProfilePerWallet,
+    tenancy: afjConfig.tenancy ?? false,
+    admin_port: adminPort,
+  })
+
+  startGauges()
 
   let token: string = ''
   const genericRecord = await agent.genericRecords.getAll()

--- a/src/events/CredentialEvents.ts
+++ b/src/events/CredentialEvents.ts
@@ -18,7 +18,7 @@ export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>
     const threadId = record.threadId ?? ''
     const jweFp = requestContext.getStore()?.jweFp ?? ''
 
-    emitStructured(LogLevel.info, {
+    emitStructured(LogLevel.trace, {
       hop: 'controller.event.credential.state',
       flow: 'issuance',
       thread_id: threadId,
@@ -45,7 +45,7 @@ export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>
         if (tenantId !== 'default') {
           await withInstrumentedTenantAgent(agent, tenantId, 'issuance', async (tenantAgent) => {
             const handlerStart = monoNow()
-            emitStructured(LogLevel.info, {
+            emitStructured(LogLevel.trace, {
               hop: 'controller.handler.entry',
               flow: 'issuance',
               thread_id: threadId,
@@ -60,7 +60,7 @@ export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>
             ])
             body.credentialData = data
             body.outOfBandId = connectionRecord?.outOfBandId ?? null
-            emitStructured(LogLevel.info, {
+            emitStructured(LogLevel.trace, {
               hop: 'controller.handler.exit',
               flow: 'issuance',
               thread_id: threadId,
@@ -74,7 +74,7 @@ export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>
           })
         } else {
           const handlerStart = monoNow()
-          emitStructured(LogLevel.info, {
+          emitStructured(LogLevel.trace, {
             hop: 'controller.handler.entry',
             flow: 'issuance',
             thread_id: threadId,
@@ -89,7 +89,7 @@ export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>
           ])
           body.credentialData = data
           body.outOfBandId = connectionRecord?.outOfBandId ?? null
-          emitStructured(LogLevel.info, {
+          emitStructured(LogLevel.trace, {
             hop: 'controller.handler.exit',
             flow: 'issuance',
             thread_id: threadId,
@@ -112,7 +112,7 @@ export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>
     } else {
       // Non-Done states: no session acquire involved — wrap the full (instant) handler.
       const handlerStart = monoNow()
-      emitStructured(LogLevel.info, {
+      emitStructured(LogLevel.trace, {
         hop: 'controller.handler.entry',
         flow: 'issuance',
         thread_id: threadId,
@@ -121,7 +121,7 @@ export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>
         tenant_id: tenantId,
         conn_id: record.connectionId ?? '',
       })
-      emitStructured(LogLevel.info, {
+      emitStructured(LogLevel.trace, {
         hop: 'controller.handler.exit',
         flow: 'issuance',
         thread_id: threadId,
@@ -138,7 +138,7 @@ export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>
     if (config.webhookUrl) {
       const webhookSpanId = makeSpanId()
       const webhookStart = monoNow()
-      emitStructured(LogLevel.info, {
+      emitStructured(LogLevel.trace, {
         hop: 'controller.webhook.fire.start',
         flow: 'issuance',
         thread_id: threadId,
@@ -148,7 +148,7 @@ export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>
       })
       recordWebhookFire()
       sendWebhookEvent(config.webhookUrl + '/credentials', body, agent.config.logger)
-      emitStructured(LogLevel.info, {
+      emitStructured(LogLevel.trace, {
         hop: 'controller.webhook.fire.end',
         flow: 'issuance',
         thread_id: threadId,

--- a/src/events/CredentialEvents.ts
+++ b/src/events/CredentialEvents.ts
@@ -16,13 +16,13 @@ export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>
     const record = event.payload.credentialRecord
     const tenantId = event.metadata.contextCorrelationId ?? 'default'
     const threadId = record.threadId ?? ''
-    const outerMsgId = requestContext.getStore()?.outerMsgId ?? ''
+    const jweFp = requestContext.getStore()?.jweFp ?? ''
 
     emitStructured(LogLevel.info, {
       hop: 'controller.event.credential.state',
       flow: 'issuance',
       thread_id: threadId,
-      outer_msg_id: outerMsgId,
+      jwe_fp: jweFp,
       tenant_id: tenantId,
       conn_id: record.connectionId ?? '',
       credential_state: record.state,
@@ -49,7 +49,7 @@ export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>
               hop: 'controller.handler.entry',
               flow: 'issuance',
               thread_id: threadId,
-              outer_msg_id: outerMsgId,
+              jwe_fp: jweFp,
               span_id: handlerSpanId,
               tenant_id: tenantId,
               conn_id: record.connectionId ?? '',
@@ -64,7 +64,7 @@ export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>
               hop: 'controller.handler.exit',
               flow: 'issuance',
               thread_id: threadId,
-              outer_msg_id: outerMsgId,
+              jwe_fp: jweFp,
               span_id: handlerSpanId,
               tenant_id: tenantId,
               conn_id: record.connectionId ?? '',
@@ -78,7 +78,7 @@ export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>
             hop: 'controller.handler.entry',
             flow: 'issuance',
             thread_id: threadId,
-            outer_msg_id: outerMsgId,
+            jwe_fp: jweFp,
             span_id: handlerSpanId,
             tenant_id: tenantId,
             conn_id: record.connectionId ?? '',
@@ -93,7 +93,7 @@ export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>
             hop: 'controller.handler.exit',
             flow: 'issuance',
             thread_id: threadId,
-            outer_msg_id: outerMsgId,
+            jwe_fp: jweFp,
             span_id: handlerSpanId,
             tenant_id: tenantId,
             conn_id: record.connectionId ?? '',
@@ -116,7 +116,7 @@ export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>
         hop: 'controller.handler.entry',
         flow: 'issuance',
         thread_id: threadId,
-        outer_msg_id: outerMsgId,
+        jwe_fp: jweFp,
         span_id: handlerSpanId,
         tenant_id: tenantId,
         conn_id: record.connectionId ?? '',
@@ -125,7 +125,7 @@ export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>
         hop: 'controller.handler.exit',
         flow: 'issuance',
         thread_id: threadId,
-        outer_msg_id: outerMsgId,
+        jwe_fp: jweFp,
         span_id: handlerSpanId,
         tenant_id: tenantId,
         conn_id: record.connectionId ?? '',

--- a/src/events/CredentialEvents.ts
+++ b/src/events/CredentialEvents.ts
@@ -2,14 +2,31 @@ import type { RestMultiTenantAgentModules } from '../cliAgent'
 import type { ServerConfig } from '../utils/ServerConfig'
 import type { Agent, CredentialStateChangedEvent } from '@credo-ts/core'
 
-import { CredentialEventTypes, CredentialState } from '@credo-ts/core'
+import { CredentialEventTypes, CredentialState, LogLevel } from '@credo-ts/core'
 
+import { emitStructured, makeSpanId, monoNow, durationMs } from '../utils/StructuredLogger'
+import { withInstrumentedTenantAgent } from '../instrumentation/tenantInstrumented'
+import { recordWebhookFire } from '../instrumentation/metrics'
+import { requestContext } from '../instrumentation/requestContext'
 import { sendWebSocketEvent } from './WebSocketEvents'
 import { sendWebhookEvent } from './WebhookEvent'
 
 export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>, config: ServerConfig) => {
   agent.events.on(CredentialEventTypes.CredentialStateChanged, async (event: CredentialStateChangedEvent) => {
     const record = event.payload.credentialRecord
+    const tenantId = event.metadata.contextCorrelationId ?? 'default'
+    const threadId = record.threadId ?? ''
+    const outerMsgId = requestContext.getStore()?.outerMsgId ?? ''
+
+    emitStructured(LogLevel.info, {
+      hop: 'controller.event.credential.state',
+      flow: 'issuance',
+      thread_id: threadId,
+      outer_msg_id: outerMsgId,
+      tenant_id: tenantId,
+      conn_id: record.connectionId ?? '',
+      credential_state: record.state,
+    })
 
     const body: Record<string, unknown> = {
       ...record.toJSON(),
@@ -17,28 +34,72 @@ export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>
       outOfBandId: null,
       credentialData: null,
     }
+    const handlerSpanId = makeSpanId()
 
     if (record.state === CredentialState.Done) {
+      // For Done state, handler.entry/exit are placed inside (or around) the
+      // session-acquire scope so handler.exit.duration_ms reflects only post-acquire
+      // work — not the semaphore wait, which is already captured in
+      // controller.session.acquire.end.duration_ms.
       try {
-        if (event.metadata.contextCorrelationId !== 'default') {
-          await agent.modules.tenants.withTenantAgent(
-            { tenantId: event.metadata.contextCorrelationId },
-            async (tenantAgent) => {
-              const [data, connectionRecord] = await Promise.all([
-                tenantAgent.credentials.getFormatData(record.id),
-                record.connectionId ? tenantAgent.connections.findById(record.connectionId) : Promise.resolve(null),
-              ])
-              body.credentialData = data
-              body.outOfBandId = connectionRecord?.outOfBandId ?? null
-            }
-          )
+        if (tenantId !== 'default') {
+          await withInstrumentedTenantAgent(agent, tenantId, 'issuance', async (tenantAgent) => {
+            const handlerStart = monoNow()
+            emitStructured(LogLevel.info, {
+              hop: 'controller.handler.entry',
+              flow: 'issuance',
+              thread_id: threadId,
+              outer_msg_id: outerMsgId,
+              span_id: handlerSpanId,
+              tenant_id: tenantId,
+              conn_id: record.connectionId ?? '',
+            })
+            const [data, connectionRecord] = await Promise.all([
+              tenantAgent.credentials.getFormatData(record.id),
+              record.connectionId ? tenantAgent.connections.findById(record.connectionId) : Promise.resolve(null),
+            ])
+            body.credentialData = data
+            body.outOfBandId = connectionRecord?.outOfBandId ?? null
+            emitStructured(LogLevel.info, {
+              hop: 'controller.handler.exit',
+              flow: 'issuance',
+              thread_id: threadId,
+              outer_msg_id: outerMsgId,
+              span_id: handlerSpanId,
+              tenant_id: tenantId,
+              conn_id: record.connectionId ?? '',
+              duration_ms: durationMs(handlerStart),
+              credential_state: record.state,
+            })
+          })
         } else {
+          const handlerStart = monoNow()
+          emitStructured(LogLevel.info, {
+            hop: 'controller.handler.entry',
+            flow: 'issuance',
+            thread_id: threadId,
+            outer_msg_id: outerMsgId,
+            span_id: handlerSpanId,
+            tenant_id: tenantId,
+            conn_id: record.connectionId ?? '',
+          })
           const [data, connectionRecord] = await Promise.all([
             agent.credentials.getFormatData(record.id),
             record.connectionId ? agent.connections.findById(record.connectionId) : Promise.resolve(null),
           ])
           body.credentialData = data
           body.outOfBandId = connectionRecord?.outOfBandId ?? null
+          emitStructured(LogLevel.info, {
+            hop: 'controller.handler.exit',
+            flow: 'issuance',
+            thread_id: threadId,
+            outer_msg_id: outerMsgId,
+            span_id: handlerSpanId,
+            tenant_id: tenantId,
+            conn_id: record.connectionId ?? '',
+            duration_ms: durationMs(handlerStart),
+            credential_state: record.state,
+          })
         }
       } catch (error) {
         agent.config.logger.error(
@@ -48,11 +109,54 @@ export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>
         body.credentialData = null
         body.outOfBandId = null
       }
+    } else {
+      // Non-Done states: no session acquire involved — wrap the full (instant) handler.
+      const handlerStart = monoNow()
+      emitStructured(LogLevel.info, {
+        hop: 'controller.handler.entry',
+        flow: 'issuance',
+        thread_id: threadId,
+        outer_msg_id: outerMsgId,
+        span_id: handlerSpanId,
+        tenant_id: tenantId,
+        conn_id: record.connectionId ?? '',
+      })
+      emitStructured(LogLevel.info, {
+        hop: 'controller.handler.exit',
+        flow: 'issuance',
+        thread_id: threadId,
+        outer_msg_id: outerMsgId,
+        span_id: handlerSpanId,
+        tenant_id: tenantId,
+        conn_id: record.connectionId ?? '',
+        duration_ms: durationMs(handlerStart),
+        credential_state: record.state,
+      })
     }
 
     // Only send webhook if webhook url is configured
     if (config.webhookUrl) {
+      const webhookSpanId = makeSpanId()
+      const webhookStart = monoNow()
+      emitStructured(LogLevel.info, {
+        hop: 'controller.webhook.fire.start',
+        flow: 'issuance',
+        thread_id: threadId,
+        span_id: webhookSpanId,
+        tenant_id: tenantId,
+        target_url: config.webhookUrl + '/credentials',
+      })
+      recordWebhookFire()
       sendWebhookEvent(config.webhookUrl + '/credentials', body, agent.config.logger)
+      emitStructured(LogLevel.info, {
+        hop: 'controller.webhook.fire.end',
+        flow: 'issuance',
+        thread_id: threadId,
+        span_id: webhookSpanId,
+        tenant_id: tenantId,
+        duration_ms: durationMs(webhookStart),
+        notes: 'fire-and-forget — timing is dispatch not delivery',
+      })
     }
 
     if (config.socketServer) {

--- a/src/events/ProofEvents.ts
+++ b/src/events/ProofEvents.ts
@@ -22,13 +22,13 @@ export const proofEvents = async (agent: Agent<RestMultiTenantAgentModules>, con
       `[ProofEvent] Proof state changed event received - threadId=${threadId}, state=${state}, contextCorrelationId=${tenantId}`
     )
 
-    const outerMsgId = requestContext.getStore()?.outerMsgId ?? ''
+    const jweFp = requestContext.getStore()?.jweFp ?? ''
 
     emitStructured(LogLevel.info, {
       hop: 'controller.event.proof.state',
       flow: 'verification',
       thread_id: threadId ?? '',
-      outer_msg_id: outerMsgId,
+      jwe_fp: jweFp,
       tenant_id: tenantId,
       conn_id: record.connectionId ?? '',
       proof_state: state,
@@ -50,7 +50,7 @@ export const proofEvents = async (agent: Agent<RestMultiTenantAgentModules>, con
               hop: 'controller.handler.entry',
               flow: 'verification',
               thread_id: threadId ?? '',
-              outer_msg_id: outerMsgId,
+              jwe_fp: jweFp,
               span_id: handlerSpanId,
               tenant_id: tenantId,
               conn_id: record.connectionId ?? '',
@@ -64,7 +64,7 @@ export const proofEvents = async (agent: Agent<RestMultiTenantAgentModules>, con
               hop: 'controller.handler.exit',
               flow: 'verification',
               thread_id: threadId ?? '',
-              outer_msg_id: outerMsgId,
+              jwe_fp: jweFp,
               span_id: handlerSpanId,
               tenant_id: tenantId,
               conn_id: record.connectionId ?? '',
@@ -78,7 +78,7 @@ export const proofEvents = async (agent: Agent<RestMultiTenantAgentModules>, con
             hop: 'controller.handler.entry',
             flow: 'verification',
             thread_id: threadId ?? '',
-            outer_msg_id: outerMsgId,
+            jwe_fp: jweFp,
             span_id: handlerSpanId,
             tenant_id: tenantId,
             conn_id: record.connectionId ?? '',
@@ -92,7 +92,7 @@ export const proofEvents = async (agent: Agent<RestMultiTenantAgentModules>, con
             hop: 'controller.handler.exit',
             flow: 'verification',
             thread_id: threadId ?? '',
-            outer_msg_id: outerMsgId,
+            jwe_fp: jweFp,
             span_id: handlerSpanId,
             tenant_id: tenantId,
             conn_id: record.connectionId ?? '',
@@ -114,7 +114,7 @@ export const proofEvents = async (agent: Agent<RestMultiTenantAgentModules>, con
         hop: 'controller.handler.entry',
         flow: 'verification',
         thread_id: threadId ?? '',
-        outer_msg_id: outerMsgId,
+        jwe_fp: jweFp,
         span_id: handlerSpanId,
         tenant_id: tenantId,
         conn_id: record.connectionId ?? '',
@@ -123,7 +123,7 @@ export const proofEvents = async (agent: Agent<RestMultiTenantAgentModules>, con
         hop: 'controller.handler.exit',
         flow: 'verification',
         thread_id: threadId ?? '',
-        outer_msg_id: outerMsgId,
+        jwe_fp: jweFp,
         span_id: handlerSpanId,
         tenant_id: tenantId,
         conn_id: record.connectionId ?? '',

--- a/src/events/ProofEvents.ts
+++ b/src/events/ProofEvents.ts
@@ -2,8 +2,12 @@ import type { RestMultiTenantAgentModules } from '../cliAgent'
 import type { ServerConfig } from '../utils/ServerConfig'
 import type { Agent, ProofStateChangedEvent } from '@credo-ts/core'
 
-import { ProofEventTypes, ProofState } from '@credo-ts/core'
+import { ProofEventTypes, ProofState, LogLevel } from '@credo-ts/core'
 
+import { emitStructured, makeSpanId, monoNow, durationMs } from '../utils/StructuredLogger'
+import { withInstrumentedTenantAgent } from '../instrumentation/tenantInstrumented'
+import { recordWebhookFire } from '../instrumentation/metrics'
+import { requestContext } from '../instrumentation/requestContext'
 import { sendWebSocketEvent } from './WebSocketEvents'
 import { sendWebhookEvent } from './WebhookEvent'
 
@@ -12,36 +16,89 @@ export const proofEvents = async (agent: Agent<RestMultiTenantAgentModules>, con
     const record = event.payload.proofRecord
     const threadId = record.threadId
     const state = record.state
+    const tenantId = event.metadata.contextCorrelationId ?? 'default'
 
     agent.config.logger.debug(
-      `[ProofEvent] Proof state changed event received - threadId=${threadId}, state=${state}, contextCorrelationId=${event.metadata.contextCorrelationId}`
+      `[ProofEvent] Proof state changed event received - threadId=${threadId}, state=${state}, contextCorrelationId=${tenantId}`
     )
 
+    const outerMsgId = requestContext.getStore()?.outerMsgId ?? ''
+
+    emitStructured(LogLevel.info, {
+      hop: 'controller.event.proof.state',
+      flow: 'verification',
+      thread_id: threadId ?? '',
+      outer_msg_id: outerMsgId,
+      tenant_id: tenantId,
+      conn_id: record.connectionId ?? '',
+      proof_state: state,
+    })
+
     const body = { ...record.toJSON(), ...event.metadata } as { proofData?: any }
+    const handlerSpanId = makeSpanId()
 
     if (record.state === ProofState.Done) {
+      // For Done state, handler.entry/exit are placed inside (or around) the
+      // session-acquire scope so handler.exit.duration_ms reflects only post-acquire
+      // work — not the semaphore wait, which is already captured in
+      // controller.session.acquire.end.duration_ms.
       try {
-        if (event.metadata.contextCorrelationId !== 'default') {
-          await agent.modules.tenants.withTenantAgent(
-            { tenantId: event.metadata.contextCorrelationId },
-            async (tenantAgent) => {
-              const data = await tenantAgent.proofs.getFormatData(record.id)
-              body.proofData = data
-              agent.config.logger.debug(
-                `[ProofEvent] Fetched proof format data for tenant agent - threadId=${threadId}, state=${state}, tenantId=${
-                  event.metadata.contextCorrelationId
-                }, data=${JSON.stringify(body)}`
-              )
-            }
-          )
+        if (tenantId !== 'default') {
+          await withInstrumentedTenantAgent(agent, tenantId, 'verification', async (tenantAgent) => {
+            const handlerStart = monoNow()
+            emitStructured(LogLevel.info, {
+              hop: 'controller.handler.entry',
+              flow: 'verification',
+              thread_id: threadId ?? '',
+              outer_msg_id: outerMsgId,
+              span_id: handlerSpanId,
+              tenant_id: tenantId,
+              conn_id: record.connectionId ?? '',
+            })
+            const data = await tenantAgent.proofs.getFormatData(record.id)
+            body.proofData = data
+            agent.config.logger.debug(
+              `[ProofEvent] Fetched proof format data for tenant agent - threadId=${threadId}, state=${state}, tenantId=${tenantId}, data=${JSON.stringify(body)}`
+            )
+            emitStructured(LogLevel.info, {
+              hop: 'controller.handler.exit',
+              flow: 'verification',
+              thread_id: threadId ?? '',
+              outer_msg_id: outerMsgId,
+              span_id: handlerSpanId,
+              tenant_id: tenantId,
+              conn_id: record.connectionId ?? '',
+              duration_ms: durationMs(handlerStart),
+              proof_state: state,
+            })
+          })
         } else {
+          const handlerStart = monoNow()
+          emitStructured(LogLevel.info, {
+            hop: 'controller.handler.entry',
+            flow: 'verification',
+            thread_id: threadId ?? '',
+            outer_msg_id: outerMsgId,
+            span_id: handlerSpanId,
+            tenant_id: tenantId,
+            conn_id: record.connectionId ?? '',
+          })
           const data = await agent.proofs.getFormatData(record.id)
           body.proofData = data
           agent.config.logger.debug(
-            `[ProofEvent] Fetched proof format data for default agent - threadId=${threadId}, state=${state}, data=${JSON.stringify(
-              body
-            )}`
+            `[ProofEvent] Fetched proof format data for default agent - threadId=${threadId}, state=${state}, data=${JSON.stringify(body)}`
           )
+          emitStructured(LogLevel.info, {
+            hop: 'controller.handler.exit',
+            flow: 'verification',
+            thread_id: threadId ?? '',
+            outer_msg_id: outerMsgId,
+            span_id: handlerSpanId,
+            tenant_id: tenantId,
+            conn_id: record.connectionId ?? '',
+            duration_ms: durationMs(handlerStart),
+            proof_state: state,
+          })
         }
       } catch (error) {
         agent.config.logger.error(
@@ -50,16 +107,57 @@ export const proofEvents = async (agent: Agent<RestMultiTenantAgentModules>, con
         )
         body.proofData = null
       }
+    } else {
+      // Non-Done states: no session acquire involved — wrap the full (instant) handler.
+      const handlerStart = monoNow()
+      emitStructured(LogLevel.info, {
+        hop: 'controller.handler.entry',
+        flow: 'verification',
+        thread_id: threadId ?? '',
+        outer_msg_id: outerMsgId,
+        span_id: handlerSpanId,
+        tenant_id: tenantId,
+        conn_id: record.connectionId ?? '',
+      })
+      emitStructured(LogLevel.info, {
+        hop: 'controller.handler.exit',
+        flow: 'verification',
+        thread_id: threadId ?? '',
+        outer_msg_id: outerMsgId,
+        span_id: handlerSpanId,
+        tenant_id: tenantId,
+        conn_id: record.connectionId ?? '',
+        duration_ms: durationMs(handlerStart),
+        proof_state: state,
+      })
     }
 
     // Only send webhook if webhook url is configured
     if (config.webhookUrl) {
       agent.config.logger.debug(
-        `[ProofEvent] Sending webhook event - threadId=${threadId}, state=${state}, webhookUrl=${
-          config.webhookUrl + '/proofs'
-        }`
+        `[ProofEvent] Sending webhook event - threadId=${threadId}, state=${state}, webhookUrl=${config.webhookUrl + '/proofs'}`
       )
+      const webhookSpanId = makeSpanId()
+      const webhookStart = monoNow()
+      emitStructured(LogLevel.info, {
+        hop: 'controller.webhook.fire.start',
+        flow: 'verification',
+        thread_id: threadId ?? '',
+        span_id: webhookSpanId,
+        tenant_id: tenantId,
+        target_url: config.webhookUrl + '/proofs',
+      })
+      recordWebhookFire()
       sendWebhookEvent(config.webhookUrl + '/proofs', body, agent.config.logger)
+      emitStructured(LogLevel.info, {
+        hop: 'controller.webhook.fire.end',
+        flow: 'verification',
+        thread_id: threadId ?? '',
+        span_id: webhookSpanId,
+        tenant_id: tenantId,
+        duration_ms: durationMs(webhookStart),
+        notes: 'fire-and-forget — timing is dispatch not delivery',
+      })
     }
 
     if (config.socketServer) {

--- a/src/events/ProofEvents.ts
+++ b/src/events/ProofEvents.ts
@@ -24,7 +24,7 @@ export const proofEvents = async (agent: Agent<RestMultiTenantAgentModules>, con
 
     const jweFp = requestContext.getStore()?.jweFp ?? ''
 
-    emitStructured(LogLevel.info, {
+    emitStructured(LogLevel.trace, {
       hop: 'controller.event.proof.state',
       flow: 'verification',
       thread_id: threadId ?? '',
@@ -46,7 +46,7 @@ export const proofEvents = async (agent: Agent<RestMultiTenantAgentModules>, con
         if (tenantId !== 'default') {
           await withInstrumentedTenantAgent(agent, tenantId, 'verification', async (tenantAgent) => {
             const handlerStart = monoNow()
-            emitStructured(LogLevel.info, {
+            emitStructured(LogLevel.trace, {
               hop: 'controller.handler.entry',
               flow: 'verification',
               thread_id: threadId ?? '',
@@ -60,7 +60,7 @@ export const proofEvents = async (agent: Agent<RestMultiTenantAgentModules>, con
             agent.config.logger.debug(
               `[ProofEvent] Fetched proof format data for tenant agent - threadId=${threadId}, state=${state}, tenantId=${tenantId}, data=${JSON.stringify(body)}`
             )
-            emitStructured(LogLevel.info, {
+            emitStructured(LogLevel.trace, {
               hop: 'controller.handler.exit',
               flow: 'verification',
               thread_id: threadId ?? '',
@@ -74,7 +74,7 @@ export const proofEvents = async (agent: Agent<RestMultiTenantAgentModules>, con
           })
         } else {
           const handlerStart = monoNow()
-          emitStructured(LogLevel.info, {
+          emitStructured(LogLevel.trace, {
             hop: 'controller.handler.entry',
             flow: 'verification',
             thread_id: threadId ?? '',
@@ -88,7 +88,7 @@ export const proofEvents = async (agent: Agent<RestMultiTenantAgentModules>, con
           agent.config.logger.debug(
             `[ProofEvent] Fetched proof format data for default agent - threadId=${threadId}, state=${state}, data=${JSON.stringify(body)}`
           )
-          emitStructured(LogLevel.info, {
+          emitStructured(LogLevel.trace, {
             hop: 'controller.handler.exit',
             flow: 'verification',
             thread_id: threadId ?? '',
@@ -110,7 +110,7 @@ export const proofEvents = async (agent: Agent<RestMultiTenantAgentModules>, con
     } else {
       // Non-Done states: no session acquire involved — wrap the full (instant) handler.
       const handlerStart = monoNow()
-      emitStructured(LogLevel.info, {
+      emitStructured(LogLevel.trace, {
         hop: 'controller.handler.entry',
         flow: 'verification',
         thread_id: threadId ?? '',
@@ -119,7 +119,7 @@ export const proofEvents = async (agent: Agent<RestMultiTenantAgentModules>, con
         tenant_id: tenantId,
         conn_id: record.connectionId ?? '',
       })
-      emitStructured(LogLevel.info, {
+      emitStructured(LogLevel.trace, {
         hop: 'controller.handler.exit',
         flow: 'verification',
         thread_id: threadId ?? '',
@@ -139,7 +139,7 @@ export const proofEvents = async (agent: Agent<RestMultiTenantAgentModules>, con
       )
       const webhookSpanId = makeSpanId()
       const webhookStart = monoNow()
-      emitStructured(LogLevel.info, {
+      emitStructured(LogLevel.trace, {
         hop: 'controller.webhook.fire.start',
         flow: 'verification',
         thread_id: threadId ?? '',
@@ -149,7 +149,7 @@ export const proofEvents = async (agent: Agent<RestMultiTenantAgentModules>, con
       })
       recordWebhookFire()
       sendWebhookEvent(config.webhookUrl + '/proofs', body, agent.config.logger)
-      emitStructured(LogLevel.info, {
+      emitStructured(LogLevel.trace, {
         hop: 'controller.webhook.fire.end',
         flow: 'verification',
         thread_id: threadId ?? '',

--- a/src/events/QuestionAnswerEvents.ts
+++ b/src/events/QuestionAnswerEvents.ts
@@ -2,7 +2,7 @@ import type { ServerConfig } from '../utils/ServerConfig'
 import type { Agent } from '@credo-ts/core'
 import type { QuestionAnswerStateChangedEvent } from '@credo-ts/question-answer'
 
-import { QuestionAnswerEventTypes } from '@credo-ts/question-answer'
+import { QuestionAnswerEventTypes, QuestionAnswerRole, QuestionAnswerState } from '@credo-ts/question-answer'
 
 import { sendWebSocketEvent } from './WebSocketEvents'
 import { sendWebhookEvent } from './WebhookEvent'
@@ -13,6 +13,22 @@ export const questionAnswerEvents = async (agent: Agent, config: ServerConfig) =
     async (event: QuestionAnswerStateChangedEvent) => {
       const record = event.payload.questionAnswerRecord
       const body = { ...record.toJSON(), ...event.metadata }
+
+      const tenantId = event.metadata.contextCorrelationId ?? 'default'
+
+      agent.config.logger.debug(
+        `[QuestionAnswerEvent] State changed - id=${record.id}, threadId=${record.threadId}, ` +
+          `role=${record.role}, state=${record.state}, connectionId=${record.connectionId}, ` +
+          `response=${record.response ?? 'none'}, contextCorrelationId=${tenantId}`
+      )
+
+      // The answer coming back from the wallet shows up as state "answer-received" on the questioner side
+      if (record.role === QuestionAnswerRole.Questioner && record.state === QuestionAnswerState.AnswerReceived) {
+        agent.config.logger.debug(
+          `[QuestionAnswerEvent] Answer received from wallet - threadId=${record.threadId}, ` +
+            `response=${record.response}, body=${JSON.stringify(body)}`
+        )
+      }
 
       // Only send webhook if webhook url is configured
       if (config.webhookUrl) {

--- a/src/instrumentation/adminEndpoint.ts
+++ b/src/instrumentation/adminEndpoint.ts
@@ -1,0 +1,52 @@
+import { LogLevel } from '@credo-ts/core'
+import type { Express, Request, Response } from 'express'
+import express from 'express'
+
+import { getDebugLogLevel, setDebugLogLevel } from './logLevelHolder'
+
+const LOG_LEVEL_MAP: Record<string, LogLevel> = {
+  test: LogLevel.test,
+  trace: LogLevel.trace,
+  debug: LogLevel.debug,
+  info: LogLevel.info,
+  warn: LogLevel.warn,
+  error: LogLevel.error,
+  fatal: LogLevel.fatal,
+  off: LogLevel.off,
+}
+
+function authMiddleware(req: Request, res: Response, next: () => void): void {
+  // Read at call time so dotenv.config() in server.ts has already run
+  const adminToken = process.env.ADMIN_TOKEN
+  if (!adminToken) {
+    res.status(503).json({ error: 'admin endpoint disabled (ADMIN_TOKEN not set)' })
+    return
+  }
+  const authHeader = req.headers['authorization']
+  if (!authHeader || authHeader !== `Bearer ${adminToken}`) {
+    res.status(401).json({ error: 'unauthorized' })
+    return
+  }
+  next()
+}
+
+export function registerAdminEndpoints(app: Express): void {
+  app.use('/admin', express.json())
+
+  app.get('/admin/log-level', authMiddleware, (_req: Request, res: Response) => {
+    const current = getDebugLogLevel()
+    const name = Object.entries(LOG_LEVEL_MAP).find(([, v]) => v === current)?.[0] ?? String(current)
+    res.json({ level: name, service: 'agent-controller' })
+  })
+
+  app.post('/admin/log-level', authMiddleware, (req: Request, res: Response) => {
+    const body = req.body as Record<string, unknown>
+    const level = body['level']
+    if (typeof level !== 'string' || !(level in LOG_LEVEL_MAP)) {
+      res.status(400).json({ error: 'invalid level', valid: Object.keys(LOG_LEVEL_MAP) })
+      return
+    }
+    setDebugLogLevel(LOG_LEVEL_MAP[level])
+    res.json({ level, service: 'agent-controller', ok: true })
+  })
+}

--- a/src/instrumentation/gauges.ts
+++ b/src/instrumentation/gauges.ts
@@ -11,7 +11,7 @@ export function startGauges(): void {
   if (_gaugeTimer) return
   _gaugeTimer = setInterval(() => {
     const snap = snapshotAndReset()
-    emitStructured(LogLevel.info, {
+    emitStructured(LogLevel.trace, {
       hop: 'controller.gauge.snapshot',
       flow: 'lifecycle',
       ...snap,

--- a/src/instrumentation/gauges.ts
+++ b/src/instrumentation/gauges.ts
@@ -1,0 +1,28 @@
+import { LogLevel } from '@credo-ts/core'
+
+import { emitStructured } from '../utils/StructuredLogger'
+import { snapshotAndReset } from './metrics'
+
+const GAUGE_INTERVAL_MS = 10_000
+
+let _gaugeTimer: ReturnType<typeof setInterval> | null = null
+
+export function startGauges(): void {
+  if (_gaugeTimer) return
+  _gaugeTimer = setInterval(() => {
+    const snap = snapshotAndReset()
+    emitStructured(LogLevel.info, {
+      hop: 'controller.gauge.snapshot',
+      flow: 'lifecycle',
+      ...snap,
+    })
+  }, GAUGE_INTERVAL_MS)
+  if (_gaugeTimer.unref) _gaugeTimer.unref()
+}
+
+export function stopGauges(): void {
+  if (_gaugeTimer) {
+    clearInterval(_gaugeTimer)
+    _gaugeTimer = null
+  }
+}

--- a/src/instrumentation/logLevelHolder.ts
+++ b/src/instrumentation/logLevelHolder.ts
@@ -1,6 +1,11 @@
 import { LogLevel } from '@credo-ts/core'
 
-let _level: LogLevel = LogLevel.info
+// Default threshold for emitStructured() instrumentation hops. The instrumentation emits at
+// `trace`, so at the `warn` default every hop (controller.handler.*, event.credential/proof.state,
+// session.acquire, jsonld.context.fetch, webhook.fire, gauge.snapshot, etc.) is suppressed —
+// production stays quiet by default. To capture them, set the level to `trace` at runtime via
+// POST /admin/log-level (the deepest, explicitly-enabled level); no redeploy needed.
+let _level: LogLevel = LogLevel.warn
 
 export function getDebugLogLevel(): LogLevel {
   return _level

--- a/src/instrumentation/logLevelHolder.ts
+++ b/src/instrumentation/logLevelHolder.ts
@@ -1,0 +1,11 @@
+import { LogLevel } from '@credo-ts/core'
+
+let _level: LogLevel = LogLevel.info
+
+export function getDebugLogLevel(): LogLevel {
+  return _level
+}
+
+export function setDebugLogLevel(level: LogLevel): void {
+  _level = level
+}

--- a/src/instrumentation/metrics.ts
+++ b/src/instrumentation/metrics.ts
@@ -1,0 +1,61 @@
+// Shared rolling counters for the controller gauge emitter.
+
+let _sessionsInFlight = 0
+let _sessionsWaiting = 0
+let _sessionsWaitedMs: number[] = []
+let _webhookFiresLast10s = 0
+
+export function sessionAcquireStart(): void {
+  _sessionsWaiting++
+}
+
+export function sessionAcquireEnd(waitMs: number): void {
+  _sessionsWaiting = Math.max(0, _sessionsWaiting - 1)
+  _sessionsInFlight++
+  _sessionsWaitedMs.push(waitMs)
+  if (_sessionsWaitedMs.length > 500) _sessionsWaitedMs.shift()
+}
+
+// Called when withTenantAgent throws before the callback is entered (e.g. timeout,
+// invalid tenant). Decrements waiting without touching in-flight.
+export function sessionAcquireFailed(): void {
+  _sessionsWaiting = Math.max(0, _sessionsWaiting - 1)
+}
+
+export function sessionReleased(): void {
+  _sessionsInFlight = Math.max(0, _sessionsInFlight - 1)
+}
+
+export function recordWebhookFire(): void {
+  _webhookFiresLast10s++
+}
+
+export interface ControllerGaugeSnapshot {
+  sessions_in_flight: number
+  sessions_waiting: number
+  session_wait_p50_ms: number | null
+  session_wait_p95_ms: number | null
+  session_wait_sample_n: number
+  webhook_fires_10s: number
+}
+
+export function snapshotAndReset(): ControllerGaugeSnapshot {
+  const sorted = [..._sessionsWaitedMs].sort((a, b) => a - b)
+  const n = sorted.length
+  const p50 = n > 0 ? sorted[Math.floor(n * 0.5)] : null
+  const p95 = n > 0 ? sorted[Math.floor(n * 0.95)] : null
+
+  const snap: ControllerGaugeSnapshot = {
+    sessions_in_flight: _sessionsInFlight,
+    sessions_waiting: _sessionsWaiting,
+    session_wait_p50_ms: p50,
+    session_wait_p95_ms: p95,
+    session_wait_sample_n: n,
+    webhook_fires_10s: _webhookFiresLast10s,
+  }
+
+  _sessionsWaitedMs = []
+  _webhookFiresLast10s = 0
+
+  return snap
+}

--- a/src/instrumentation/metrics.ts
+++ b/src/instrumentation/metrics.ts
@@ -30,6 +30,10 @@ export function recordWebhookFire(): void {
   _webhookFiresLast10s++
 }
 
+export function getSessionPoolStats(): { sessionsInFlight: number; sessionsWaiting: number } {
+  return { sessionsInFlight: _sessionsInFlight, sessionsWaiting: _sessionsWaiting }
+}
+
 export interface ControllerGaugeSnapshot {
   sessions_in_flight: number
   sessions_waiting: number

--- a/src/instrumentation/requestContext.ts
+++ b/src/instrumentation/requestContext.ts
@@ -1,0 +1,9 @@
+import { AsyncLocalStorage } from 'async_hooks'
+
+export interface RequestContext {
+  outerMsgId: string
+}
+
+// Carries per-request context (outer_msg_id extracted at HTTP inbound)
+// through Credo's async processing chain to the event handlers.
+export const requestContext = new AsyncLocalStorage<RequestContext>()

--- a/src/instrumentation/requestContext.ts
+++ b/src/instrumentation/requestContext.ts
@@ -1,9 +1,9 @@
 import { AsyncLocalStorage } from 'async_hooks'
 
 export interface RequestContext {
-  outerMsgId: string
+  jweFp: string
 }
 
-// Carries per-request context (outer_msg_id extracted at HTTP inbound)
-// through Credo's async processing chain to the event handlers.
+// Carries the JWE fingerprint (`iv`) extracted at HTTP inbound through Credo's
+// async processing chain to event handlers and the session acquire wrapper.
 export const requestContext = new AsyncLocalStorage<RequestContext>()

--- a/src/instrumentation/tenantInstrumented.ts
+++ b/src/instrumentation/tenantInstrumented.ts
@@ -1,0 +1,122 @@
+import type { RestMultiTenantAgentModules } from '../cliAgent'
+import type { Agent } from '@credo-ts/core'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type TenantAgent = any
+
+import { LogLevel } from '@credo-ts/core'
+
+import { emitStructured, makeSpanId, monoNow, durationMs } from '../utils/StructuredLogger'
+import { sessionAcquireStart, sessionAcquireEnd, sessionAcquireFailed, sessionReleased } from './metrics'
+import { requestContext } from './requestContext'
+
+type TenantCallback<T> = (tenantAgent: TenantAgent) => Promise<T>
+
+export async function withInstrumentedTenantAgent<T>(
+  agent: Agent<RestMultiTenantAgentModules>,
+  tenantId: string,
+  flow: 'issuance' | 'verification',
+  callback: TenantCallback<T>
+): Promise<T> {
+  const resolveSpanId = makeSpanId()
+  const resolveStart = monoNow()
+
+  const outerMsgId = requestContext.getStore()?.outerMsgId ?? ''
+
+  emitStructured(LogLevel.debug, {
+    hop: 'controller.tenant.resolve.start',
+    flow,
+    span_id: resolveSpanId,
+    tenant_id: tenantId,
+    outer_msg_id: outerMsgId,
+  })
+
+  // Session acquire timing starts before withTenantAgent (which blocks on the semaphore)
+  const acquireSpanId = makeSpanId()
+  const acquireStart = monoNow()
+  sessionAcquireStart()
+
+  emitStructured(LogLevel.info, {
+    hop: 'controller.session.acquire.start',
+    flow,
+    span_id: acquireSpanId,
+    tenant_id: tenantId,
+    outer_msg_id: outerMsgId,
+  })
+
+  // Tracks whether withTenantAgent entered the callback. If it throws before
+  // doing so (timeout, invalid tenant), we must call sessionAcquireFailed()
+  // instead of sessionReleased() to avoid phantom in-flight counts.
+  let callbackEntered = false
+
+  try {
+    const result = await agent.modules.tenants.withTenantAgent({ tenantId }, async (tenantAgent) => {
+      callbackEntered = true
+      const waitMs = durationMs(acquireStart)
+      sessionAcquireEnd(waitMs)
+
+      emitStructured(LogLevel.info, {
+        hop: 'controller.session.acquire.end',
+        flow,
+        span_id: acquireSpanId,
+        tenant_id: tenantId,
+        outer_msg_id: outerMsgId,
+        wait_ms: waitMs,
+        duration_ms: waitMs,
+      })
+      emitStructured(LogLevel.debug, {
+        hop: 'controller.tenant.resolve.end',
+        flow,
+        span_id: resolveSpanId,
+        tenant_id: tenantId,
+        outer_msg_id: outerMsgId,
+        duration_ms: durationMs(resolveStart),
+      })
+
+      // Measure first Askar access (wallet open / profile attach) for H8.
+      const walletSpanId = makeSpanId()
+      const walletStart = monoNow()
+      emitStructured(LogLevel.debug, {
+        hop: 'controller.wallet.open.start',
+        flow,
+        span_id: walletSpanId,
+        tenant_id: tenantId,
+      })
+      // The first awaited operation in the callback triggers the wallet open.
+      // We ping genericRecords as the lightest available read that forces it.
+      try {
+        await tenantAgent.genericRecords.getAll()
+      } catch {
+        // ignore — only measuring timing; the callback may not need genericRecords
+      }
+      emitStructured(LogLevel.debug, {
+        hop: 'controller.wallet.open.end',
+        flow,
+        span_id: walletSpanId,
+        tenant_id: tenantId,
+        duration_ms: durationMs(walletStart),
+      })
+
+      return callback(tenantAgent)
+    })
+    return result
+  } catch (err) {
+    if (!callbackEntered) {
+      // withTenantAgent failed before the session was acquired (semaphore timeout,
+      // invalid tenant, etc.). Decrement waiting without touching in-flight.
+      sessionAcquireFailed()
+      emitStructured(LogLevel.info, {
+        hop: 'controller.session.acquire.end',
+        flow,
+        span_id: acquireSpanId,
+        tenant_id: tenantId,
+        outer_msg_id: outerMsgId,
+        duration_ms: durationMs(acquireStart),
+        notes: `acquire_failed: ${String(err)}`,
+      })
+    }
+    throw err
+  } finally {
+    if (callbackEntered) sessionReleased()
+  }
+}

--- a/src/instrumentation/tenantInstrumented.ts
+++ b/src/instrumentation/tenantInstrumented.ts
@@ -6,7 +6,7 @@ type TenantAgent = any
 
 import { LogLevel } from '@credo-ts/core'
 
-import { emitStructured, makeSpanId, monoNow, durationMs } from '../utils/StructuredLogger'
+import { emitStructured, isInstrumentationEnabled, makeSpanId, monoNow, durationMs } from '../utils/StructuredLogger'
 import { sessionAcquireStart, sessionAcquireEnd, sessionAcquireFailed, sessionReleased, getSessionPoolStats } from './metrics'
 import { requestContext } from './requestContext'
 
@@ -18,6 +18,13 @@ export async function withInstrumentedTenantAgent<T>(
   flow: 'issuance' | 'verification',
   callback: TenantCallback<T>
 ): Promise<T> {
+  // When instrumentation is off, run the stock tenant agent directly — no
+  // session-acquire timing, no metrics, and crucially no extra wallet-open probe
+  // query (genericRecords.getAll) per tenant operation.
+  if (!isInstrumentationEnabled()) {
+    return agent.modules.tenants.withTenantAgent({ tenantId }, (tenantAgent: TenantAgent) => callback(tenantAgent))
+  }
+
   const resolveSpanId = makeSpanId()
   const resolveStart = monoNow()
 

--- a/src/instrumentation/tenantInstrumented.ts
+++ b/src/instrumentation/tenantInstrumented.ts
@@ -23,7 +23,7 @@ export async function withInstrumentedTenantAgent<T>(
 
   const jweFp = requestContext.getStore()?.jweFp ?? ''
 
-  emitStructured(LogLevel.debug, {
+  emitStructured(LogLevel.trace, {
     hop: 'controller.tenant.resolve.start',
     flow,
     span_id: resolveSpanId,
@@ -36,7 +36,7 @@ export async function withInstrumentedTenantAgent<T>(
   const acquireStart = monoNow()
   sessionAcquireStart()
 
-  emitStructured(LogLevel.info, {
+  emitStructured(LogLevel.trace, {
     hop: 'controller.session.acquire.start',
     flow,
     span_id: acquireSpanId,
@@ -56,7 +56,7 @@ export async function withInstrumentedTenantAgent<T>(
       sessionAcquireEnd(waitMs)
       const { sessionsInFlight, sessionsWaiting } = getSessionPoolStats()
 
-      emitStructured(LogLevel.info, {
+      emitStructured(LogLevel.trace, {
         hop: 'controller.session.acquire.end',
         flow,
         span_id: acquireSpanId,
@@ -67,7 +67,7 @@ export async function withInstrumentedTenantAgent<T>(
         sessions_in_use: sessionsInFlight,
         sessions_waiting: sessionsWaiting,
       })
-      emitStructured(LogLevel.debug, {
+      emitStructured(LogLevel.trace, {
         hop: 'controller.tenant.resolve.end',
         flow,
         span_id: resolveSpanId,
@@ -79,7 +79,7 @@ export async function withInstrumentedTenantAgent<T>(
       // Measure first Askar access (wallet open / profile attach) for H8.
       const walletSpanId = makeSpanId()
       const walletStart = monoNow()
-      emitStructured(LogLevel.debug, {
+      emitStructured(LogLevel.trace, {
         hop: 'controller.wallet.open.start',
         flow,
         span_id: walletSpanId,
@@ -92,7 +92,7 @@ export async function withInstrumentedTenantAgent<T>(
       } catch {
         // ignore — only measuring timing; the callback may not need genericRecords
       }
-      emitStructured(LogLevel.debug, {
+      emitStructured(LogLevel.trace, {
         hop: 'controller.wallet.open.end',
         flow,
         span_id: walletSpanId,
@@ -108,7 +108,7 @@ export async function withInstrumentedTenantAgent<T>(
       // withTenantAgent failed before the session was acquired (semaphore timeout,
       // invalid tenant, etc.). Decrement waiting without touching in-flight.
       sessionAcquireFailed()
-      emitStructured(LogLevel.info, {
+      emitStructured(LogLevel.trace, {
         hop: 'controller.session.acquire.end',
         flow,
         span_id: acquireSpanId,

--- a/src/instrumentation/tenantInstrumented.ts
+++ b/src/instrumentation/tenantInstrumented.ts
@@ -7,7 +7,7 @@ type TenantAgent = any
 import { LogLevel } from '@credo-ts/core'
 
 import { emitStructured, makeSpanId, monoNow, durationMs } from '../utils/StructuredLogger'
-import { sessionAcquireStart, sessionAcquireEnd, sessionAcquireFailed, sessionReleased } from './metrics'
+import { sessionAcquireStart, sessionAcquireEnd, sessionAcquireFailed, sessionReleased, getSessionPoolStats } from './metrics'
 import { requestContext } from './requestContext'
 
 type TenantCallback<T> = (tenantAgent: TenantAgent) => Promise<T>
@@ -21,14 +21,14 @@ export async function withInstrumentedTenantAgent<T>(
   const resolveSpanId = makeSpanId()
   const resolveStart = monoNow()
 
-  const outerMsgId = requestContext.getStore()?.outerMsgId ?? ''
+  const jweFp = requestContext.getStore()?.jweFp ?? ''
 
   emitStructured(LogLevel.debug, {
     hop: 'controller.tenant.resolve.start',
     flow,
     span_id: resolveSpanId,
     tenant_id: tenantId,
-    outer_msg_id: outerMsgId,
+    jwe_fp: jweFp,
   })
 
   // Session acquire timing starts before withTenantAgent (which blocks on the semaphore)
@@ -41,7 +41,7 @@ export async function withInstrumentedTenantAgent<T>(
     flow,
     span_id: acquireSpanId,
     tenant_id: tenantId,
-    outer_msg_id: outerMsgId,
+    jwe_fp: jweFp,
   })
 
   // Tracks whether withTenantAgent entered the callback. If it throws before
@@ -54,22 +54,25 @@ export async function withInstrumentedTenantAgent<T>(
       callbackEntered = true
       const waitMs = durationMs(acquireStart)
       sessionAcquireEnd(waitMs)
+      const { sessionsInFlight, sessionsWaiting } = getSessionPoolStats()
 
       emitStructured(LogLevel.info, {
         hop: 'controller.session.acquire.end',
         flow,
         span_id: acquireSpanId,
         tenant_id: tenantId,
-        outer_msg_id: outerMsgId,
+        jwe_fp: jweFp,
         wait_ms: waitMs,
         duration_ms: waitMs,
+        sessions_in_use: sessionsInFlight,
+        sessions_waiting: sessionsWaiting,
       })
       emitStructured(LogLevel.debug, {
         hop: 'controller.tenant.resolve.end',
         flow,
         span_id: resolveSpanId,
         tenant_id: tenantId,
-        outer_msg_id: outerMsgId,
+        jwe_fp: jweFp,
         duration_ms: durationMs(resolveStart),
       })
 
@@ -110,7 +113,7 @@ export async function withInstrumentedTenantAgent<T>(
         flow,
         span_id: acquireSpanId,
         tenant_id: tenantId,
-        outer_msg_id: outerMsgId,
+        jwe_fp: jweFp,
         duration_ms: durationMs(acquireStart),
         notes: `acquire_failed: ${String(err)}`,
       })

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,6 +15,7 @@ import { container } from 'tsyringe'
 import { setDynamicApiKey } from './authentication'
 import { BaseError } from './errors/errors'
 import { registerAdminEndpoints } from './instrumentation/adminEndpoint'
+import { isInstrumentationEnabled } from './utils/StructuredLogger'
 import { basicMessageEvents } from './events/BasicMessageEvents'
 import { connectionEvents } from './events/ConnectionEvents'
 import { credentialEvents } from './events/CredentialEvents'
@@ -79,8 +80,9 @@ export const setupServer = async (agent: Agent, config: ServerConfig, apiKey?: s
 
   // Admin endpoints are mounted before SecurityMiddleware so the Bearer-token
   // check in authMiddleware is the sole guard on /admin routes — the API-key
-  // middleware must not intercept them first.
-  registerAdminEndpoints(app)
+  // middleware must not intercept them first. Only mounted when instrumentation
+  // is enabled (there is nothing to toggle otherwise).
+  if (isInstrumentationEnabled()) registerAdminEndpoints(app)
 
   const securityMiddleware = new SecurityMiddleware()
   app.use(securityMiddleware.use)

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,6 +14,7 @@ import { container } from 'tsyringe'
 
 import { setDynamicApiKey } from './authentication'
 import { BaseError } from './errors/errors'
+import { registerAdminEndpoints } from './instrumentation/adminEndpoint'
 import { basicMessageEvents } from './events/BasicMessageEvents'
 import { connectionEvents } from './events/ConnectionEvents'
 import { credentialEvents } from './events/CredentialEvents'
@@ -75,6 +76,11 @@ export const setupServer = async (agent: Agent, config: ServerConfig, apiKey?: s
     }
     next()
   })
+
+  // Admin endpoints are mounted before SecurityMiddleware so the Bearer-token
+  // check in authMiddleware is the sole guard on /admin routes — the API-key
+  // middleware must not intercept them first.
+  registerAdminEndpoints(app)
 
   const securityMiddleware = new SecurityMiddleware()
   app.use(securityMiddleware.use)

--- a/src/utils/CachedDocumentLoader.ts
+++ b/src/utils/CachedDocumentLoader.ts
@@ -42,7 +42,7 @@ export const buildCachedDocumentLoader = (logger: TsLogger): DocumentLoaderWithC
 
         if (cached) {
           logger.debug(`Document loader cache hit for: ${url}`)
-          emitStructured(LogLevel.info, {
+          emitStructured(LogLevel.trace, {
             hop: 'controller.jsonld.context.fetch.end',
             span_id: _fetchSpanId,
             jwe_fp: requestContext.getStore()?.jweFp ?? '',
@@ -61,7 +61,7 @@ export const buildCachedDocumentLoader = (logger: TsLogger): DocumentLoaderWithC
       // Cache miss — fetch via default loader
       logger.debug(`Document loader cache miss — fetching: ${url}`)
 
-      emitStructured(LogLevel.info, {
+      emitStructured(LogLevel.trace, {
         hop: 'controller.jsonld.context.fetch.start',
         span_id: _fetchSpanId,
         jwe_fp: requestContext.getStore()?.jweFp ?? '',
@@ -74,7 +74,7 @@ export const buildCachedDocumentLoader = (logger: TsLogger): DocumentLoaderWithC
 
       try {
         document = await defaultLoader(url)
-        emitStructured(LogLevel.info, {
+        emitStructured(LogLevel.trace, {
           hop: 'controller.jsonld.context.fetch.end',
           span_id: _fetchSpanId,
           jwe_fp: requestContext.getStore()?.jweFp ?? '',
@@ -84,7 +84,7 @@ export const buildCachedDocumentLoader = (logger: TsLogger): DocumentLoaderWithC
           url,
         })
       } catch (err) {
-        emitStructured(LogLevel.info, {
+        emitStructured(LogLevel.trace, {
           hop: 'controller.jsonld.context.fetch.end',
           span_id: _fetchSpanId,
           jwe_fp: requestContext.getStore()?.jweFp ?? '',

--- a/src/utils/CachedDocumentLoader.ts
+++ b/src/utils/CachedDocumentLoader.ts
@@ -3,120 +3,396 @@ import type { AgentContext } from '@credo-ts/core'
 import type { DocumentLoaderWithContext } from '@credo-ts/core/build/modules/vc/data-integrity/libraries/documentLoader'
 import type { DocumentLoaderResult } from '@credo-ts/core/build/modules/vc/data-integrity/libraries/jsonld'
 
-import { CacheModuleConfig } from '@credo-ts/core'
+import { CacheModuleConfig, LogLevel } from '@credo-ts/core'
+import { DidResolverService } from '@credo-ts/core/build/modules/dids'
+import { DEFAULT_CONTEXTS } from '@credo-ts/core/build/modules/vc/data-integrity/libraries/contexts'
 import { defaultDocumentLoader } from '@credo-ts/core/build/modules/vc/data-integrity/libraries/documentLoader'
-import { LogLevel } from '@credo-ts/core'
 
-import { emitStructured, makeSpanId, monoNow, durationMs } from './StructuredLogger'
 import { requestContext } from '../instrumentation/requestContext'
 
-const DOCUMENT_LOADER_CACHE_PREFIX = 'jsonld:document:'
-const DOCUMENT_CACHE_TTL_SECONDS = 60 * 60 * 24 * 7 // 7 days
-const SCHEMA_SERVER_URL = process.env.SERVER_URL ?? 'https://dev-schema.ngotag.com'
+import { emitStructured, makeSpanId, monoNow, durationMs } from './StructuredLogger'
+import { SECP256K1_RECOVERY_2020_V2 } from './staticContexts/secp256k1recovery2020v2'
 
-const NGOTAG_SCHEMA_PREFIX = `${SCHEMA_SERVER_URL}/schemas/`
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+const DOC_CACHE_PREFIX = 'jsonld:document:'
+const DOC_TTL_SECONDS = 60 * 60 * 24 * 7 // 7 days
+const FETCH_TIMEOUT_MS = Number(process.env.JSONLD_FETCH_TIMEOUT_MS) || 3_000
+// DID resolution gets a longer budget: Redis commandTimeout (~3 s) can be
+// fully consumed before RPC resolution even starts, so reusing FETCH_TIMEOUT_MS
+// for the DID path guarantees failure whenever Redis is degraded.
+const DID_RESOLVE_TIMEOUT_MS = Number(process.env.DID_RESOLVE_TIMEOUT_MS) || 12_000
+const MAX_DOC_BYTES = Number(process.env.JSONLD_MAX_DOC_BYTES) || 256 * 1024
+const LRU_MAX = Number(process.env.INMEMORY_LRU_CACHE_LIMIT) || 500
+
+// ---------------------------------------------------------------------------
+// Layer 1 — static contexts embedded at build time (zero network, Redis-immune)
+//
+// Add any context here that (a) is not in Credo DEFAULT_CONTEXTS and (b)
+// appears in DID documents or VPs we verify. Both the canonical w3id.org URL
+// and the identity.foundation redirect target are mapped so whichever arrives
+// is served in-process without a network round-trip.
+// ---------------------------------------------------------------------------
+const STATIC_CONTEXTS: Record<string, unknown> = {
+  'https://w3id.org/security/suites/secp256k1recovery-2020/v2': SECP256K1_RECOVERY_2020_V2,
+  'https://identity.foundation/EcdsaSecp256k1RecoverySignature2020/lds-ecdsa-secp256k1-recovery2020-2.0.jsonld':
+    SECP256K1_RECOVERY_2020_V2,
+}
+
+// ---------------------------------------------------------------------------
+// Layer 2 — allowlist: the only hosts we will ever FETCH from.
+//
+// Closes the SSRF vector present in the prior implementation (every non-schema
+// URL in a presented credential was fetched live, unchecked). A URL whose host
+// is not in this set is rejected immediately — no network call, no session held.
+//
+// Extend at runtime: ALLOWED_CONTEXT_HOSTS=host1.com,host2.com
+// ---------------------------------------------------------------------------
+const schemaHost = (() => {
+  try {
+    // Fall back to the default schema server so dev-schema.ngotag.com stays
+    // allowlisted when SERVER_URL is not set (preserves pre-PR behaviour).
+    return new URL(process.env.SERVER_URL ?? 'https://dev-schema.ngotag.com').host
+  } catch {
+    return ''
+  }
+})()
+
+const ALLOWED_CONTEXT_HOSTS = new Set<string>([
+  'www.w3.org',
+  'w3.org',
+  'w3id.org',
+  'identity.foundation',
+  ...(schemaHost ? [schemaHost] : []),
+  ...(process.env.ALLOWED_CONTEXT_HOSTS ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean),
+])
+
+// ---------------------------------------------------------------------------
+// Layer 3a — in-process LRU (survives a Redis outage on the hot path)
+//
+// Minimal LRU backed by an insertion-ordered Map — no external dependency.
+// ---------------------------------------------------------------------------
+class SimpleLRU<V> {
+  private readonly cache = new Map<string, V>()
+
+  public constructor(private readonly max: number) {}
+
+  public get(key: string): V | undefined {
+    if (!this.cache.has(key)) return undefined
+    const v = this.cache.get(key)!
+    this.cache.delete(key)
+    this.cache.set(key, v) // refresh to most-recently-used end
+    return v
+  }
+
+  public set(key: string, value: V): void {
+    if (this.cache.has(key)) {
+      this.cache.delete(key)
+    } else if (this.cache.size >= this.max) {
+      this.cache.delete(this.cache.keys().next().value as string) // evict LRU
+    }
+    this.cache.set(key, value)
+  }
+}
+
+const memCache = new SimpleLRU<DocumentLoaderResult>(LRU_MAX)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+const withTimeout = <T>(p: Promise<T>, ms: number, url: string): Promise<T> =>
+  new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`document loader timeout after ${ms}ms for ${url}`)), ms)
+    timer.unref() // don't keep the Node.js event loop alive for this timer alone
+    p.then(
+      (val) => {
+        clearTimeout(timer)
+        resolve(val)
+      },
+      (err) => {
+        clearTimeout(timer)
+        reject(err)
+      }
+    )
+  })
+
+// ---------------------------------------------------------------------------
+// Loader factory
+// ---------------------------------------------------------------------------
+// jsonld is accessed via require to avoid adding import = require to the ESM
+// import section (which triggers import/order group-boundary errors). The
+// eslint-disable block covers the require call regardless of Prettier layout.
+/* eslint-disable @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports */
+const jsonld = (
+  require('@credo-ts/core/build/modules/vc/data-integrity/libraries/jsonld') as {
+    default: { frame(input: object, frame: object, options?: object): Promise<object> }
+  }
+).default
+/* eslint-enable @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports */
 
 export const buildCachedDocumentLoader = (logger: TsLogger): DocumentLoaderWithContext => {
-  // Return a factory function that Credo calls with agentContext
   return (agentContext: AgentContext) => {
-    // Get the default Credo loader for this context
-    // handles: bundled DEFAULT_CONTEXTS, DID resolution, basic HTTP
     const defaultLoader = defaultDocumentLoader(agentContext)
+    const getCache = () => agentContext.dependencyManager.resolve(CacheModuleConfig).cache
 
-    return async (url: string): Promise<DocumentLoaderResult> => {
-      // Let Credo handle bundled contexts and DIDs natively
-      const shouldCache = url.startsWith(NGOTAG_SCHEMA_PREFIX)
-      if (!shouldCache) {
-        return defaultLoader(url)
+    const wrappedLoader = async (url: string): Promise<DocumentLoaderResult> => {
+      const noFrag = url.split('#')[0]
+      const spanId = makeSpanId()
+      const start = monoNow()
+      const jweFp = requestContext.getStore()?.jweFp ?? ''
+
+      // ------------------------------------------------------------------
+      // 1a) STATIC contexts — embedded in bundle, zero network, Redis-immune
+      // ------------------------------------------------------------------
+      const staticDoc = STATIC_CONTEXTS[url] ?? STATIC_CONTEXTS[noFrag]
+      if (staticDoc) {
+        logger.debug(`Document loader static hit: ${url}`)
+        emitStructured(LogLevel.trace, {
+          hop: 'controller.jsonld.context.fetch.end',
+          span_id: spanId,
+          jwe_fp: jweFp,
+          tenant_id: '',
+          duration_ms: durationMs(start),
+          cache_hit: true,
+          url,
+          notes: 'static',
+        })
+        return { contextUrl: null, documentUrl: url, document: staticDoc as Record<string, unknown> }
       }
 
-      // Check cache for external URLs
-      const cacheKey = `${DOCUMENT_LOADER_CACHE_PREFIX}${url}`
-      const _fetchSpanId = makeSpanId()
-      const _fetchStart = monoNow()
+      // ------------------------------------------------------------------
+      // 1b) Credo DEFAULT_CONTEXTS bundle — also zero network
+      // ------------------------------------------------------------------
+      const bundledCtx =
+        (DEFAULT_CONTEXTS as Record<string, unknown>)[url] ?? (DEFAULT_CONTEXTS as Record<string, unknown>)[noFrag]
+      if (bundledCtx) {
+        logger.debug(`Document loader Credo-bundled hit: ${url}`)
+        emitStructured(LogLevel.trace, {
+          hop: 'controller.jsonld.context.fetch.end',
+          span_id: spanId,
+          jwe_fp: jweFp,
+          tenant_id: '',
+          duration_ms: durationMs(start),
+          cache_hit: true,
+          url,
+          notes: 'credo_bundled',
+        })
+        return { contextUrl: null, documentUrl: url, document: bundledCtx as Record<string, unknown> }
+      }
 
-      try {
-        const cache = agentContext.dependencyManager.resolve(CacheModuleConfig).cache
-
-        const cached = await cache.get<DocumentLoaderResult>(agentContext, cacheKey)
-
-        if (cached) {
-          logger.debug(`Document loader cache hit for: ${url}`)
+      // ------------------------------------------------------------------
+      // 2) non-HTTP URL — did: URLs are resolved here directly so that
+      //    nested @context loads (e.g. secp256k1recovery-2020/v2 in
+      //    did:ethr DID documents) route through wrappedLoader → layers
+      //    1a–5, rather than Credo's inner loader which would do a live
+      //    fetch bypassing the static map, allowlist, LRU, and Redis.
+      //    Non-DID non-HTTP URLs fall back to defaultLoader unchanged.
+      //
+      //    DID_RESOLVE_TIMEOUT_MS is intentionally larger than
+      //    FETCH_TIMEOUT_MS: Redis commandTimeout (~3 s) can be fully
+      //    consumed before RPC resolution starts, so a 3 s budget
+      //    guarantees failure whenever Redis is degraded.
+      // ------------------------------------------------------------------
+      const isHttp = url.startsWith('http://') || url.startsWith('https://')
+      if (!isHttp) {
+        emitStructured(LogLevel.trace, {
+          hop: 'controller.jsonld.context.fetch.start',
+          span_id: spanId,
+          jwe_fp: jweFp,
+          tenant_id: '',
+          cache_hit: false,
+          url,
+        })
+        let resolveNotes = 'did_resolve'
+        try {
+          let result: DocumentLoaderResult
+          if (url.startsWith('did:')) {
+            result = await withTimeout(
+              (async () => {
+                const didResolver = agentContext.dependencyManager.resolve(DidResolverService)
+                const resolution = await didResolver.resolve(agentContext, url)
+                if (resolution.didResolutionMetadata.error || !resolution.didDocument) {
+                  throw new Error(
+                    `Unable to resolve DID: ${url}: ${resolution.didResolutionMetadata.error ?? 'no document'}`
+                  )
+                }
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore – jsonld typings do not expose documentLoader option
+                const framed = await jsonld.frame(
+                  resolution.didDocument.toJSON(),
+                  { '@context': resolution.didDocument.context, '@embed': '@never', id: url },
+                  { documentLoader: wrappedLoader }
+                )
+                return { contextUrl: null, documentUrl: url, document: framed as Record<string, unknown> }
+              })(),
+              DID_RESOLVE_TIMEOUT_MS,
+              url
+            )
+            resolveNotes = 'did_resolve_wrapped'
+          } else {
+            result = await withTimeout(defaultLoader(url), FETCH_TIMEOUT_MS, url)
+          }
           emitStructured(LogLevel.trace, {
             hop: 'controller.jsonld.context.fetch.end',
-            span_id: _fetchSpanId,
-            jwe_fp: requestContext.getStore()?.jweFp ?? '',
+            span_id: spanId,
+            jwe_fp: jweFp,
             tenant_id: '',
-            duration_ms: durationMs(_fetchStart),
-            cache_hit: true,
+            duration_ms: durationMs(start),
+            cache_hit: false,
             url,
+            notes: resolveNotes,
           })
-          return cached
+          return result
+        } catch (err) {
+          emitStructured(LogLevel.trace, {
+            hop: 'controller.jsonld.context.fetch.end',
+            span_id: spanId,
+            jwe_fp: jweFp,
+            tenant_id: '',
+            duration_ms: durationMs(start),
+            cache_hit: false,
+            url,
+            notes: `did_resolve_error: ${String(err)}`,
+          })
+          logger.error(`Document loader DID resolve failed: ${url}: ${err}`)
+          throw err
         }
-      } catch (err) {
-        // Cache unavailable — fall through to HTTP fetch
-        logger.warn(`Document loader cache unavailable for ${url}: ${err}`)
       }
 
-      // Cache miss — fetch via default loader
-      logger.debug(`Document loader cache miss — fetching: ${url}`)
+      // ------------------------------------------------------------------
+      // 3) Allowlist gate — SSRF prevention.
+      //    Unknown host → immediate rejection, no network call, session freed.
+      // ------------------------------------------------------------------
+      let host = ''
+      try {
+        host = new URL(url).host
+      } catch {
+        /* invalid URL — falls through to rejection below */
+      }
+      if (!host || !ALLOWED_CONTEXT_HOSTS.has(host)) {
+        logger.error(`Document loader BLOCKED non-allowlisted context: ${url}`)
+        throw new Error(`document loader: context host not allowlisted: ${host || url}`)
+      }
 
+      // ------------------------------------------------------------------
+      // 4a) In-memory LRU
+      //     Serves allowlisted contexts even while Redis is timing out.
+      //     This is the primary defence against the current Redis-timeout
+      //     trigger: once a context is loaded once, it never touches Redis.
+      // ------------------------------------------------------------------
+      const memHit = memCache.get(url)
+      if (memHit) {
+        logger.debug(`Document loader in-memory LRU hit: ${url}`)
+        emitStructured(LogLevel.trace, {
+          hop: 'controller.jsonld.context.fetch.end',
+          span_id: spanId,
+          jwe_fp: jweFp,
+          tenant_id: '',
+          duration_ms: durationMs(start),
+          cache_hit: true,
+          url,
+          notes: 'lru',
+        })
+        return memHit
+      }
+
+      // ------------------------------------------------------------------
+      // 4b) Redis — commandTimeout already enforced by RedisCache (3 s).
+      //     Any error is treated as a cache miss; never a hang.
+      // ------------------------------------------------------------------
+      const cacheKey = `${DOC_CACHE_PREFIX}${url}`
+      try {
+        const redisHit = await getCache().get<DocumentLoaderResult>(agentContext, cacheKey)
+        if (redisHit) {
+          memCache.set(url, redisHit) // promote to LRU for future hits
+          logger.debug(`Document loader Redis cache hit: ${url}`)
+          emitStructured(LogLevel.trace, {
+            hop: 'controller.jsonld.context.fetch.end',
+            span_id: spanId,
+            jwe_fp: jweFp,
+            tenant_id: '',
+            duration_ms: durationMs(start),
+            cache_hit: true,
+            url,
+            notes: 'redis',
+          })
+          return redisHit
+        }
+      } catch (err) {
+        logger.warn(`Document loader Redis get failed (treating as miss) ${url}: ${err}`)
+      }
+
+      // ------------------------------------------------------------------
+      // 5) Allowlisted cache miss — fetch with a hard timeout.
+      //    The timeout guarantees this path always releases the session slot
+      //    even if the remote context server is slow or unreachable.
+      // ------------------------------------------------------------------
       emitStructured(LogLevel.trace, {
         hop: 'controller.jsonld.context.fetch.start',
-        span_id: _fetchSpanId,
-        jwe_fp: requestContext.getStore()?.jweFp ?? '',
+        span_id: spanId,
+        jwe_fp: jweFp,
         tenant_id: '',
         cache_hit: false,
         url,
       })
 
-      let document: DocumentLoaderResult
-
+      let doc: DocumentLoaderResult
       try {
-        document = await defaultLoader(url)
-        emitStructured(LogLevel.trace, {
-          hop: 'controller.jsonld.context.fetch.end',
-          span_id: _fetchSpanId,
-          jwe_fp: requestContext.getStore()?.jweFp ?? '',
-          tenant_id: '',
-          duration_ms: durationMs(_fetchStart),
-          cache_hit: false,
-          url,
-        })
+        doc = await withTimeout(defaultLoader(url), FETCH_TIMEOUT_MS, url)
       } catch (err) {
         emitStructured(LogLevel.trace, {
           hop: 'controller.jsonld.context.fetch.end',
-          span_id: _fetchSpanId,
-          jwe_fp: requestContext.getStore()?.jweFp ?? '',
+          span_id: spanId,
+          jwe_fp: jweFp,
           tenant_id: '',
-          duration_ms: durationMs(_fetchStart),
+          duration_ms: durationMs(start),
           cache_hit: false,
           url,
           notes: `fetch_error: ${String(err)}`,
         })
-        logger.error(`Document loader failed to fetch ${url}: ${err}`)
+        logger.error(`Document loader fetch failed/timeout ${url}: ${err}`)
         throw err
       }
 
-      // Cache the fetched document
-      try {
-        const cache = agentContext.dependencyManager.resolve(CacheModuleConfig).cache
+      emitStructured(LogLevel.trace, {
+        hop: 'controller.jsonld.context.fetch.end',
+        span_id: spanId,
+        jwe_fp: jweFp,
+        tenant_id: '',
+        duration_ms: durationMs(start),
+        cache_hit: false,
+        url,
+      })
 
-        await cache.set(
-          agentContext,
-          cacheKey,
-          {
-            contextUrl: document.contextUrl,
-            documentUrl: document.documentUrl,
-            document: document.document,
-          },
-          DOCUMENT_CACHE_TTL_SECONDS
-        )
-        logger.debug(`Document loader cached successfully: ${url}`)
+      // Size-capped write-through to both caches
+      try {
+        const docSize = Buffer.byteLength(JSON.stringify(doc.document))
+        if (docSize <= MAX_DOC_BYTES) {
+          memCache.set(url, doc)
+          await getCache().set(
+            agentContext,
+            cacheKey,
+            {
+              contextUrl: doc.contextUrl,
+              documentUrl: doc.documentUrl,
+              document: doc.document,
+            },
+            DOC_TTL_SECONDS
+          )
+          logger.debug(`Document loader cached: ${url} (${docSize} bytes)`)
+        } else {
+          logger.warn(`Document loader doc too large to cache (${docSize} bytes): ${url}`)
+        }
       } catch (err) {
-        logger.warn(`Failed to cache document for ${url}: ${err}`)
+        logger.warn(`Document loader cache write failed ${url}: ${err}`)
       }
-      return document
+
+      return doc
     }
+    return wrappedLoader
   }
 }

--- a/src/utils/CachedDocumentLoader.ts
+++ b/src/utils/CachedDocumentLoader.ts
@@ -10,7 +10,7 @@ import { defaultDocumentLoader } from '@credo-ts/core/build/modules/vc/data-inte
 
 import { requestContext } from '../instrumentation/requestContext'
 
-import { emitStructured, makeSpanId, monoNow, durationMs } from './StructuredLogger'
+import { emitStructured, isInstrumentationEnabled, makeSpanId, monoNow, durationMs } from './StructuredLogger'
 import { SECP256K1_RECOVERY_2020_V2 } from './staticContexts/secp256k1recovery2020v2'
 
 // ---------------------------------------------------------------------------
@@ -141,9 +141,10 @@ export const buildCachedDocumentLoader = (logger: TsLogger): DocumentLoaderWithC
 
     const wrappedLoader = async (url: string): Promise<DocumentLoaderResult> => {
       const noFrag = url.split('#')[0]
-      const spanId = makeSpanId()
-      const start = monoNow()
-      const jweFp = requestContext.getStore()?.jweFp ?? ''
+      const enabled = isInstrumentationEnabled()
+      const spanId = enabled ? makeSpanId() : ''
+      const start = enabled ? monoNow() : 0
+      const jweFp = enabled ? requestContext.getStore()?.jweFp ?? '' : ''
 
       // ------------------------------------------------------------------
       // 1a) STATIC contexts — embedded in bundle, zero network, Redis-immune
@@ -156,7 +157,7 @@ export const buildCachedDocumentLoader = (logger: TsLogger): DocumentLoaderWithC
           span_id: spanId,
           jwe_fp: jweFp,
           tenant_id: '',
-          duration_ms: durationMs(start),
+          duration_ms: enabled ? durationMs(start) : undefined,
           cache_hit: true,
           url,
           notes: 'static',
@@ -176,7 +177,7 @@ export const buildCachedDocumentLoader = (logger: TsLogger): DocumentLoaderWithC
           span_id: spanId,
           jwe_fp: jweFp,
           tenant_id: '',
-          duration_ms: durationMs(start),
+          duration_ms: enabled ? durationMs(start) : undefined,
           cache_hit: true,
           url,
           notes: 'credo_bundled',
@@ -241,7 +242,7 @@ export const buildCachedDocumentLoader = (logger: TsLogger): DocumentLoaderWithC
             span_id: spanId,
             jwe_fp: jweFp,
             tenant_id: '',
-            duration_ms: durationMs(start),
+            duration_ms: enabled ? durationMs(start) : undefined,
             cache_hit: false,
             url,
             notes: resolveNotes,
@@ -253,7 +254,7 @@ export const buildCachedDocumentLoader = (logger: TsLogger): DocumentLoaderWithC
             span_id: spanId,
             jwe_fp: jweFp,
             tenant_id: '',
-            duration_ms: durationMs(start),
+            duration_ms: enabled ? durationMs(start) : undefined,
             cache_hit: false,
             url,
             notes: `did_resolve_error: ${String(err)}`,
@@ -292,7 +293,7 @@ export const buildCachedDocumentLoader = (logger: TsLogger): DocumentLoaderWithC
           span_id: spanId,
           jwe_fp: jweFp,
           tenant_id: '',
-          duration_ms: durationMs(start),
+          duration_ms: enabled ? durationMs(start) : undefined,
           cache_hit: true,
           url,
           notes: 'lru',
@@ -315,7 +316,7 @@ export const buildCachedDocumentLoader = (logger: TsLogger): DocumentLoaderWithC
             span_id: spanId,
             jwe_fp: jweFp,
             tenant_id: '',
-            duration_ms: durationMs(start),
+            duration_ms: enabled ? durationMs(start) : undefined,
             cache_hit: true,
             url,
             notes: 'redis',
@@ -349,7 +350,7 @@ export const buildCachedDocumentLoader = (logger: TsLogger): DocumentLoaderWithC
           span_id: spanId,
           jwe_fp: jweFp,
           tenant_id: '',
-          duration_ms: durationMs(start),
+          duration_ms: enabled ? durationMs(start) : undefined,
           cache_hit: false,
           url,
           notes: `fetch_error: ${String(err)}`,
@@ -363,7 +364,7 @@ export const buildCachedDocumentLoader = (logger: TsLogger): DocumentLoaderWithC
         span_id: spanId,
         jwe_fp: jweFp,
         tenant_id: '',
-        duration_ms: durationMs(start),
+        duration_ms: enabled ? durationMs(start) : undefined,
         cache_hit: false,
         url,
       })

--- a/src/utils/CachedDocumentLoader.ts
+++ b/src/utils/CachedDocumentLoader.ts
@@ -5,6 +5,10 @@ import type { DocumentLoaderResult } from '@credo-ts/core/build/modules/vc/data-
 
 import { CacheModuleConfig } from '@credo-ts/core'
 import { defaultDocumentLoader } from '@credo-ts/core/build/modules/vc/data-integrity/libraries/documentLoader'
+import { LogLevel } from '@credo-ts/core'
+
+import { emitStructured, makeSpanId, monoNow, durationMs } from './StructuredLogger'
+import { requestContext } from '../instrumentation/requestContext'
 
 const DOCUMENT_LOADER_CACHE_PREFIX = 'jsonld:document:'
 const DOCUMENT_CACHE_TTL_SECONDS = 60 * 60 * 24 * 7 // 7 days
@@ -28,6 +32,8 @@ export const buildCachedDocumentLoader = (logger: TsLogger): DocumentLoaderWithC
 
       // Check cache for external URLs
       const cacheKey = `${DOCUMENT_LOADER_CACHE_PREFIX}${url}`
+      const _fetchSpanId = makeSpanId()
+      const _fetchStart = monoNow()
 
       try {
         const cache = agentContext.dependencyManager.resolve(CacheModuleConfig).cache
@@ -36,6 +42,15 @@ export const buildCachedDocumentLoader = (logger: TsLogger): DocumentLoaderWithC
 
         if (cached) {
           logger.debug(`Document loader cache hit for: ${url}`)
+          emitStructured(LogLevel.info, {
+            hop: 'controller.jsonld.context.fetch.end',
+            span_id: _fetchSpanId,
+            outer_msg_id: requestContext.getStore()?.outerMsgId ?? '',
+            tenant_id: '',
+            duration_ms: durationMs(_fetchStart),
+            cache_hit: true,
+            url,
+          })
           return cached
         }
       } catch (err) {
@@ -46,11 +61,39 @@ export const buildCachedDocumentLoader = (logger: TsLogger): DocumentLoaderWithC
       // Cache miss — fetch via default loader
       logger.debug(`Document loader cache miss — fetching: ${url}`)
 
+      emitStructured(LogLevel.info, {
+        hop: 'controller.jsonld.context.fetch.start',
+        span_id: _fetchSpanId,
+        outer_msg_id: requestContext.getStore()?.outerMsgId ?? '',
+        tenant_id: '',
+        cache_hit: false,
+        url,
+      })
+
       let document: DocumentLoaderResult
 
       try {
         document = await defaultLoader(url)
+        emitStructured(LogLevel.info, {
+          hop: 'controller.jsonld.context.fetch.end',
+          span_id: _fetchSpanId,
+          outer_msg_id: requestContext.getStore()?.outerMsgId ?? '',
+          tenant_id: '',
+          duration_ms: durationMs(_fetchStart),
+          cache_hit: false,
+          url,
+        })
       } catch (err) {
+        emitStructured(LogLevel.info, {
+          hop: 'controller.jsonld.context.fetch.end',
+          span_id: _fetchSpanId,
+          outer_msg_id: requestContext.getStore()?.outerMsgId ?? '',
+          tenant_id: '',
+          duration_ms: durationMs(_fetchStart),
+          cache_hit: false,
+          url,
+          notes: `fetch_error: ${String(err)}`,
+        })
         logger.error(`Document loader failed to fetch ${url}: ${err}`)
         throw err
       }

--- a/src/utils/CachedDocumentLoader.ts
+++ b/src/utils/CachedDocumentLoader.ts
@@ -45,7 +45,7 @@ export const buildCachedDocumentLoader = (logger: TsLogger): DocumentLoaderWithC
           emitStructured(LogLevel.info, {
             hop: 'controller.jsonld.context.fetch.end',
             span_id: _fetchSpanId,
-            outer_msg_id: requestContext.getStore()?.outerMsgId ?? '',
+            jwe_fp: requestContext.getStore()?.jweFp ?? '',
             tenant_id: '',
             duration_ms: durationMs(_fetchStart),
             cache_hit: true,
@@ -64,7 +64,7 @@ export const buildCachedDocumentLoader = (logger: TsLogger): DocumentLoaderWithC
       emitStructured(LogLevel.info, {
         hop: 'controller.jsonld.context.fetch.start',
         span_id: _fetchSpanId,
-        outer_msg_id: requestContext.getStore()?.outerMsgId ?? '',
+        jwe_fp: requestContext.getStore()?.jweFp ?? '',
         tenant_id: '',
         cache_hit: false,
         url,
@@ -77,7 +77,7 @@ export const buildCachedDocumentLoader = (logger: TsLogger): DocumentLoaderWithC
         emitStructured(LogLevel.info, {
           hop: 'controller.jsonld.context.fetch.end',
           span_id: _fetchSpanId,
-          outer_msg_id: requestContext.getStore()?.outerMsgId ?? '',
+          jwe_fp: requestContext.getStore()?.jweFp ?? '',
           tenant_id: '',
           duration_ms: durationMs(_fetchStart),
           cache_hit: false,
@@ -87,7 +87,7 @@ export const buildCachedDocumentLoader = (logger: TsLogger): DocumentLoaderWithC
         emitStructured(LogLevel.info, {
           hop: 'controller.jsonld.context.fetch.end',
           span_id: _fetchSpanId,
-          outer_msg_id: requestContext.getStore()?.outerMsgId ?? '',
+          jwe_fp: requestContext.getStore()?.jweFp ?? '',
           tenant_id: '',
           duration_ms: durationMs(_fetchStart),
           cache_hit: false,

--- a/src/utils/StructuredLogger.ts
+++ b/src/utils/StructuredLogger.ts
@@ -49,7 +49,21 @@ export interface StructuredLogLine {
 
 const TASK_HOST = process.env.HOSTNAME || os.hostname()
 
+// Master switch for the latency debug instrumentation (env INSTRUMENTATION_ENABLED,
+// default off). When off, emitStructured() is a no-op and the following wiring is
+// skipped: HTTP inbound middleware, the instrumented tenant wrapper, pool gauges,
+// and the admin endpoint. Call sites that compute span IDs or durations before
+// calling emitStructured() still incur that lightweight overhead regardless.
+// When on, /admin/log-level controls verbosity.
+//
+// Read at call time (not module-init) so that dotenv.config() in server.ts — which
+// runs after imports are evaluated — is visible here without any load-order changes.
+export function isInstrumentationEnabled(): boolean {
+  return process.env.INSTRUMENTATION_ENABLED === 'true'
+}
+
 export function emitStructured(level: LogLevel, line: StructuredLogLine): void {
+  if (!isInstrumentationEnabled()) return
   if (level < getDebugLogLevel()) return
 
   const out: Record<string, unknown> = {

--- a/src/utils/StructuredLogger.ts
+++ b/src/utils/StructuredLogger.ts
@@ -36,7 +36,7 @@ export interface StructuredLogLine {
   hop: HopName
   flow?: FlowType
   thread_id?: string
-  outer_msg_id?: string
+  jwe_fp?: string
   recipient_key_short?: string
   tenant_id?: string
   conn_id?: string
@@ -84,36 +84,61 @@ export function truncateKey(key: string): string {
   return key.slice(0, 6) + '…' + key.slice(-6)
 }
 
-export function tryExtractFromJwe(rawBody: string): { recipientKeyShort: string; outerMsgId: string } {
+// Extracts the JWE top-level `iv` as a per-message fingerprint and the recipient key
+// for cross-service log correlation.
+export function tryExtractFromJwe(rawBody: string): { recipientKeyShort: string; jweFp: string } {
   try {
     const parsed = JSON.parse(rawBody) as Record<string, unknown>
     let recipientKeyShort = ''
-    let outerMsgId = ''
 
-    // recipients is a top-level JWE JSON field, not inside the protected header
+    // Try top-level recipients first (standard JWE General JSON Serialization)
     const recipients = parsed['recipients']
     if (Array.isArray(recipients) && recipients.length > 0) {
       const firstRecip = recipients[0] as Record<string, unknown>
       const hdr = firstRecip['header'] as Record<string, unknown> | undefined
       const kid = hdr?.['kid']
-      if (typeof kid === 'string') recipientKeyShort = truncateKey(kid)
+      if (typeof kid === 'string' && kid.length > 0) recipientKeyShort = truncateKey(kid)
     }
 
-    // @id is non-standard in JWE but check the protected header anyway
-    const protectedB64 = parsed['protected']
-    if (typeof protectedB64 === 'string') {
-      try {
-        const headerStr = Buffer.from(protectedB64, 'base64').toString('utf8')
-        const header = JSON.parse(headerStr) as Record<string, unknown>
-        const id = header['@id'] || header['id']
-        if (typeof id === 'string') outerMsgId = id
-      } catch {
-        // ignore
+    // Fall back: Aries DIDComm v1 Authcrypt puts recipients inside the protected header
+    if (!recipientKeyShort) {
+      const protectedB64 = parsed['protected']
+      if (typeof protectedB64 === 'string') {
+        try {
+          const headerStr = Buffer.from(protectedB64, 'base64').toString('utf8')
+          const header = JSON.parse(headerStr) as Record<string, unknown>
+          const innerRecipients = header['recipients']
+          if (Array.isArray(innerRecipients) && innerRecipients.length > 0) {
+            const first = innerRecipients[0] as Record<string, unknown>
+            const hdr = first['header'] as Record<string, unknown> | undefined
+            const kid = hdr?.['kid']
+            if (typeof kid === 'string') recipientKeyShort = truncateKey(kid)
+          }
+        } catch {
+          // ignore
+        }
       }
     }
 
-    return { recipientKeyShort, outerMsgId }
+    // iv fingerprint: unique per JWE encryption, visible at both ends without decryption
+    const iv = parsed['iv']
+    const jweFp = typeof iv === 'string' ? iv : ''
+
+    return { recipientKeyShort, jweFp }
   } catch {
-    return { recipientKeyShort: '', outerMsgId: '' }
+    return { recipientKeyShort: '', jweFp: '' }
+  }
+}
+
+export function tryExtractJweFp(payload: unknown): string {
+  try {
+    const parsed: Record<string, unknown> =
+      typeof payload === 'string'
+        ? (JSON.parse(payload) as Record<string, unknown>)
+        : (payload as Record<string, unknown>)
+    const iv = parsed['iv']
+    return typeof iv === 'string' ? iv : ''
+  } catch {
+    return ''
   }
 }

--- a/src/utils/StructuredLogger.ts
+++ b/src/utils/StructuredLogger.ts
@@ -1,0 +1,119 @@
+import { LogLevel } from '@credo-ts/core'
+import * as os from 'os'
+
+import { getDebugLogLevel } from '../instrumentation/logLevelHolder'
+
+export type HopName =
+  | 'controller.config.dump'
+  | 'controller.http.inbound.received'
+  | 'controller.tenant.resolve.start'
+  | 'controller.tenant.resolve.end'
+  | 'controller.session.acquire.start'
+  | 'controller.session.acquire.end'
+  | 'controller.wallet.open.start'
+  | 'controller.wallet.open.end'
+  | 'controller.handler.entry'
+  | 'controller.handler.exit'
+  | 'controller.jsonld.context.fetch.start'
+  | 'controller.jsonld.context.fetch.end'
+  | 'controller.askar.query.start'
+  | 'controller.askar.query.end'
+  | 'controller.event.proof.state'
+  | 'controller.event.credential.state'
+  | 'controller.webhook.fire.start'
+  | 'controller.webhook.fire.end'
+  | 'controller.gauge.snapshot'
+
+export type FlowType =
+  | 'connection'
+  | 'issuance'
+  | 'verification'
+  | 'pickup'
+  | 'mediation-coord'
+  | 'lifecycle'
+
+export interface StructuredLogLine {
+  hop: HopName
+  flow?: FlowType
+  thread_id?: string
+  outer_msg_id?: string
+  recipient_key_short?: string
+  tenant_id?: string
+  conn_id?: string
+  span_id?: string
+  duration_ms?: number
+  wait_ms?: number
+  notes?: string
+  [key: string]: unknown
+}
+
+const TASK_HOST = process.env.HOSTNAME || os.hostname()
+
+export function emitStructured(level: LogLevel, line: StructuredLogLine): void {
+  if (level < getDebugLogLevel()) return
+
+  const out: Record<string, unknown> = {
+    ts: new Date().toISOString(),
+    ts_mono_ns: Number(process.hrtime.bigint()),
+    service: 'agent-controller',
+    task_host: TASK_HOST,
+    ...line,
+  }
+
+  for (const key of Object.keys(out)) {
+    if (out[key] === undefined) delete out[key]
+  }
+
+  process.stdout.write(JSON.stringify(out) + '\n')
+}
+
+export function makeSpanId(): string {
+  return Math.random().toString(36).slice(2, 10) + Math.random().toString(36).slice(2, 10)
+}
+
+export function monoNow(): number {
+  return Number(process.hrtime.bigint())
+}
+
+export function durationMs(startMono: number): number {
+  return Math.round((Number(process.hrtime.bigint()) - startMono) / 1e6)
+}
+
+export function truncateKey(key: string): string {
+  if (key.length <= 14) return key
+  return key.slice(0, 6) + '…' + key.slice(-6)
+}
+
+export function tryExtractFromJwe(rawBody: string): { recipientKeyShort: string; outerMsgId: string } {
+  try {
+    const parsed = JSON.parse(rawBody) as Record<string, unknown>
+    let recipientKeyShort = ''
+    let outerMsgId = ''
+
+    // recipients is a top-level JWE JSON field, not inside the protected header
+    const recipients = parsed['recipients']
+    if (Array.isArray(recipients) && recipients.length > 0) {
+      const firstRecip = recipients[0] as Record<string, unknown>
+      const hdr = firstRecip['header'] as Record<string, unknown> | undefined
+      const kid = hdr?.['kid']
+      if (typeof kid === 'string') recipientKeyShort = truncateKey(kid)
+    }
+
+    // @id is non-standard in JWE but check the protected header anyway
+    const protectedB64 = parsed['protected']
+    if (typeof protectedB64 === 'string') {
+      try {
+        const headerStr = Buffer.from(protectedB64, 'base64').toString('utf8')
+        const header = JSON.parse(headerStr) as Record<string, unknown>
+        const id = header['@id'] || header['id']
+        if (typeof id === 'string') outerMsgId = id
+      } catch {
+        // ignore
+      }
+    }
+
+    return { recipientKeyShort, outerMsgId }
+  } catch {
+    return { recipientKeyShort: '', outerMsgId: '' }
+  }
+}

--- a/src/utils/StructuredLogger.ts
+++ b/src/utils/StructuredLogger.ts
@@ -129,16 +129,3 @@ export function tryExtractFromJwe(rawBody: string): { recipientKeyShort: string;
     return { recipientKeyShort: '', jweFp: '' }
   }
 }
-
-export function tryExtractJweFp(payload: unknown): string {
-  try {
-    const parsed: Record<string, unknown> =
-      typeof payload === 'string'
-        ? (JSON.parse(payload) as Record<string, unknown>)
-        : (payload as Record<string, unknown>)
-    const iv = parsed['iv']
-    return typeof iv === 'string' ? iv : ''
-  } catch {
-    return ''
-  }
-}

--- a/src/utils/staticContexts/secp256k1recovery2020v2.ts
+++ b/src/utils/staticContexts/secp256k1recovery2020v2.ts
@@ -1,0 +1,112 @@
+/**
+ * Embedded JSON-LD context for EcdsaSecp256k1RecoverySignature2020 v2.
+ *
+ * Canonical URL : https://w3id.org/security/suites/secp256k1recovery-2020/v2
+ * Resolves to   : https://identity.foundation/EcdsaSecp256k1RecoverySignature2020/
+ *                   lds-ecdsa-secp256k1-recovery2020-2.0.jsonld
+ *
+ * This context defines EcdsaSecp256k1RecoveryMethod2020, EcdsaSecp256k1RecoverySignature2020,
+ * blockchainAccountId, and related terms used by did:ethr DID documents and credentials
+ * signed with the Ethereum secp256k1 recovery suite.
+ *
+ * IMPORTANT: this object MUST be byte-identical (modulo key ordering) to the canonical
+ * document. JSON-LD signature verification canonicalises (URDNA2015) against it — any
+ * added/removed/changed term silently breaks proof verification. Do NOT edit by hand;
+ * re-fetch and diff instead:
+ *   curl -sL https://w3id.org/security/suites/secp256k1recovery-2020/v2 | jq -S .
+ *
+ * Verified against the canonical document on 2026-06-12.
+ *
+ * Embedded here to eliminate the network dependency from the JSON-LD verification
+ * hot path (see CachedDocumentLoader.ts, Layer 1).
+ */
+export const SECP256K1_RECOVERY_2020_V2 = {
+  '@context': {
+    id: '@id',
+    type: '@type',
+    '@protected': true,
+
+    proof: {
+      '@id': 'https://w3id.org/security#proof',
+      '@type': '@id',
+      '@container': '@graph',
+    },
+
+    EcdsaSecp256k1RecoveryMethod2020: {
+      '@id': 'https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#EcdsaSecp256k1RecoveryMethod2020',
+      '@context': {
+        '@protected': true,
+        id: '@id',
+        type: '@type',
+        controller: {
+          '@id': 'https://w3id.org/security#controller',
+          '@type': '@id',
+        },
+        blockchainAccountId: 'https://w3id.org/security#blockchainAccountId',
+        publicKeyJwk: {
+          '@id': 'https://w3id.org/security#publicKeyJwk',
+          '@type': '@json',
+        },
+      },
+    },
+
+    EcdsaSecp256k1RecoverySignature2020: {
+      '@id': 'https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#EcdsaSecp256k1RecoverySignature2020',
+      '@context': {
+        '@protected': true,
+        id: '@id',
+        type: '@type',
+        challenge: 'https://w3id.org/security#challenge',
+        created: {
+          '@id': 'http://purl.org/dc/terms/created',
+          '@type': 'http://www.w3.org/2001/XMLSchema#dateTime',
+        },
+        domain: 'https://w3id.org/security#domain',
+        expires: {
+          '@id': 'https://w3id.org/security#expiration',
+          '@type': 'http://www.w3.org/2001/XMLSchema#dateTime',
+        },
+        jws: 'https://w3id.org/security#jws',
+        nonce: 'https://w3id.org/security#nonce',
+        proofPurpose: {
+          '@id': 'https://w3id.org/security#proofPurpose',
+          '@type': '@vocab',
+          '@context': {
+            '@protected': true,
+            id: '@id',
+            type: '@type',
+            assertionMethod: {
+              '@id': 'https://w3id.org/security#assertionMethod',
+              '@type': '@id',
+              '@container': '@set',
+            },
+            authentication: {
+              '@id': 'https://w3id.org/security#authenticationMethod',
+              '@type': '@id',
+              '@container': '@set',
+            },
+            capabilityInvocation: {
+              '@id': 'https://w3id.org/security#capabilityInvocationMethod',
+              '@type': '@id',
+              '@container': '@set',
+            },
+            capabilityDelegation: {
+              '@id': 'https://w3id.org/security#capabilityDelegationMethod',
+              '@type': '@id',
+              '@container': '@set',
+            },
+            keyAgreement: {
+              '@id': 'https://w3id.org/security#keyAgreementMethod',
+              '@type': '@id',
+              '@container': '@set',
+            },
+          },
+        },
+        verificationMethod: {
+          '@id': 'https://w3id.org/security#verificationMethod',
+          '@type': '@id',
+        },
+      },
+    },
+  },
+} as const

--- a/tests/tenant-session-pool.regression.test.ts
+++ b/tests/tenant-session-pool.regression.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Regression test — agent-context session pool leak / freeze.
+ *
+ * Root cause (confirmed on staging 2026-07): a tenant session slot could be acquired
+ * (TenantSessionMutex.currentSessions++) without a matching release when work failed on
+ * an un-guarded path (e.g. TenantsApi.getTenantAgent -> tenantAgent.initialize() throwing,
+ * or TenantSessionCoordinator.endAgentContextSession throwing before releaseSession()).
+ * Leaked slots accumulate until currentSessions pins at SESSION_LIMIT; the session mutex
+ * then never unlocks and every subsequent request waits SESSION_ACQUIRE_TIMEOUT and fails,
+ * until the process is restarted.
+ *
+ * Fix (patch @credo-ts+tenants+0.5.3+002): every acquired slot is released on every path
+ * (release moved into finally / release-on-initialize-failure / undo increment on failed lock).
+ *
+ * These tests exercise the REAL vendored TenantSessionMutex and guard the invariant the fix
+ * enforces: no matter how in-session work fails, the pool drains back to 0 and never wedges.
+ * (Full end-to-end validation is the staging load test + `leakcheck` — see
+ *  Debug/STAGE/SOLUTION-PLAN-session-pool-leak.md.)
+ */
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+import { TenantSessionMutex } from '@credo-ts/tenants/build/context/TenantSessionMutex'
+
+// Minimal logger stub matching the TsLogger surface the mutex uses.
+const logger: any = { debug: () => {}, info: () => {}, warn: () => {}, error: () => {}, trace: () => {} }
+
+// Mirrors the fixed acquire→work→release contract (release in finally).
+const withSession = async (mutex: any, work: () => Promise<void>): Promise<void> => {
+  await mutex.acquireSession()
+  try {
+    await work()
+  } finally {
+    mutex.releaseSession()
+  }
+}
+
+describe('tenant session pool — leak/freeze regression', () => {
+  it('drains to 0 and stays unlocked after many balanced acquire/release cycles', async () => {
+    const mutex: any = new TenantSessionMutex(logger, 100, 10000)
+    for (let i = 0; i < 500; i++) {
+      await mutex.acquireSession()
+      mutex.releaseSession()
+    }
+    expect(mutex.currentSessions).toBe(0)
+    expect(mutex.sessionMutex.isLocked()).toBe(false)
+  })
+
+  it('never wedges even when a large fraction of in-session work throws', async () => {
+    const mutex: any = new TenantSessionMutex(logger, 10, 2000)
+    for (let i = 0; i < 200; i++) {
+      try {
+        await withSession(mutex, async () => {
+          if (i % 3 === 0) throw new Error('simulated initialize()/callback failure')
+        })
+      } catch {
+        // expected for the failing third of iterations
+      }
+    }
+    // With release guaranteed in finally, the pool is fully drained despite ~1/3 failing.
+    expect(mutex.currentSessions).toBe(0)
+    expect(mutex.sessionMutex.isLocked()).toBe(false)
+    // And a fresh request still acquires immediately (pool not frozen).
+    await expect(mutex.acquireSession()).resolves.toBeUndefined()
+    mutex.releaseSession()
+  })
+
+  it('documents the failure mode: skipping release on error wedges the pool at the ceiling', async () => {
+    const mutex: any = new TenantSessionMutex(logger, 3, 300)
+    // Simulate the pre-fix leak: acquire, then work throws and release is SKIPPED.
+    for (let i = 0; i < 3; i++) {
+      try {
+        await mutex.acquireSession()
+        throw new Error('initialize failed — release skipped (pre-fix behaviour)')
+      } catch {
+        /* leaked slot */
+      }
+    }
+    // Counter pinned at the limit and the mutex is stuck locked.
+    expect(mutex.currentSessions).toBe(3)
+    expect(mutex.sessionMutex.isLocked()).toBe(true)
+    // A healthy request can no longer get in — it times out: the production freeze.
+    await expect(mutex.acquireSession()).rejects.toThrow(/Failed to acquire an agent context session/)
+  })
+})


### PR DESCRIPTION
## Summary

Forward-ports the accumulated `deployment` work into `pipeline-implementation`.
`pipeline-implementation` was last synced from `deployment` via #43; `deployment` has
since advanced **14 commits ahead** (1 behind — the #43 merge commit — so GitHub will
create a merge commit rather than fast-forward).

Groups of changes included:

### Session pool stability
- **fix(tenants): release agent-context session slot on all paths to prevent pool freeze** (`ca33f3f`)
  — patches `@credo-ts/tenants@0.5.3` so an acquired tenant session slot is always released
  (release in `finally`; release on `initialize()` failure; undo increment on failed post-increment
  lock). Fixes the staging freeze where `currentSessions` pinned at `SESSION_LIMIT` and every request
  hung until an ECS restart. Adds `tests/tenant-session-pool.regression.test.ts`.

### Instrumentation / observability
- feat(instrumentation): `INSTRUMENTATION_ENABLED` master switch, default off (#50)
- debug: latency instrumentation (#46) — tenant-instrumented wrappers, gauges, metrics, request context
- fix(instrumentation): replace `outer_msg_id` with `jwe_fp`; add session pool stats gauge
- chore(instrumentation): default structured-log threshold to `warn` (#48)
- refactor(instrumentation): remove unused `tryExtractJweFp` helper
- Structured logging: `StructuredLogger`, `logLevelHolder`, admin endpoint for log level

### JSON-LD / did:ethr
- fix(jsonld): route `did:ethr` context loads through the wrapped document loader (#51)
- Add `secp256k1recovery2020v2` static context; substantial `CachedDocumentLoader` rework

### Ethereum env configuration
- fix: pick ETH-related env vars from `.env` to automate deployment
- fix: use a single `rpcUrl` for ETH
- fix: remove unused `ETHEREUM_REGISTRY` fallback and duplicate `chainId`/`name`/`registry`

### Event logging
- fix: enhance `QuestionAnswer` event logging with role and state information

## Diffstat
18 files changed, ~1548 insertions, ~97 deletions (see the Files tab). Notable: `src/instrumentation/*`,
`src/utils/CachedDocumentLoader.ts`, `src/events/{Credential,Proof,QuestionAnswer}Events.ts`,
`patches/@credo-ts+tenants+0.5.3+002+session-release-exception-safe.patch`.

## Notes for reviewers
- Branches have diverged (not a fast-forward); resolve the merge on GitHub.
- `INSTRUMENTATION_ENABLED` defaults **off**, so instrumentation is inert unless explicitly enabled.
- New env vars are documented in the updated `.env.sample`.
