### PR TITLE
[General] refactor(events): gate format-data on Done + fire-and-forget webhooks (#38)

### DIFF
--- a/src/events/BasicMessageEvents.ts
+++ b/src/events/BasicMessageEvents.ts
@@ -16,7 +16,7 @@ export const basicMessageEvents = async (agent: Agent, config: ServerConfig) => 
 
       // Only send webhook if webhook url is configured
       if (config.webhookUrl) {
-        await sendWebhookEvent(config.webhookUrl + '/basic-messages', body, agent.config.logger)
+        void sendWebhookEvent(config.webhookUrl + '/basic-messages', body, agent.config.logger)
       }
 
       if (config.socketServer) {

--- a/src/events/ConnectionEvents.ts
+++ b/src/events/ConnectionEvents.ts
@@ -16,7 +16,7 @@ export const connectionEvents = async (agent: Agent, config: ServerConfig) => {
 
       // Only send webhook if webhook url is configured
       if (config.webhookUrl) {
-        await sendWebhookEvent(config.webhookUrl + '/connections', body, agent.config.logger)
+        void sendWebhookEvent(config.webhookUrl + '/connections', body, agent.config.logger)
       }
 
       if (config.socketServer) {

--- a/src/events/CredentialEvents.ts
+++ b/src/events/CredentialEvents.ts
@@ -3,7 +3,7 @@ import type { ServerConfig } from '../utils/ServerConfig'
 import type { Agent } from '@credo-ts/core'
 import type { DidCommCredentialStateChangedEvent } from '@credo-ts/didcomm'
 
-import { DidCommCredentialEventTypes } from '@credo-ts/didcomm'
+import { DidCommCredentialEventTypes, DidCommCredentialState } from '@credo-ts/didcomm'
 
 import { sendWebSocketEvent } from './WebSocketEvents'
 import { sendWebhookEvent } from './WebhookEvent'
@@ -26,39 +26,44 @@ export const credentialEvents = async (agent: Agent, config: ServerConfig) => {
         credentialData: null,
       }
 
-      if (record?.connectionId) {
-        let connectionRecord
-        if (tenantId && tenantId !== 'default') {
-          await (agent as Agent<RestMultiTenantAgentModules>).modules.tenants.withTenantAgent(
-            { tenantId: body.contextCorrelationId as string },
-            async (tenantAgent) => {
-              connectionRecord = await tenantAgent.modules.didcomm.connections.findById(
-                record.connectionId ? record.connectionId : '',
-              )
-            },
+      if (record.state === DidCommCredentialState.Done) {
+        try {
+          if (tenantId && tenantId !== 'default') {
+            await (agent as Agent<RestMultiTenantAgentModules>).modules.tenants.withTenantAgent(
+              { tenantId: body.contextCorrelationId as string },
+              async (tenantAgent) => {
+                const [data, connectionRecord] = await Promise.all([
+                  tenantAgent.modules.didcomm.credentials.getFormatData(record.id),
+                  record.connectionId
+                    ? tenantAgent.modules.didcomm.connections.findById(record.connectionId)
+                    : Promise.resolve(null),
+                ])
+                body.credentialData = data
+                body.outOfBandId = connectionRecord?.outOfBandId ?? null
+              },
+            )
+          } else {
+            const [data, connectionRecord] = await Promise.all([
+              agent.modules.didcomm.credentials.getFormatData(record.id),
+              record.connectionId
+                ? agent.modules.didcomm.connections.findById(record.connectionId)
+                : Promise.resolve(null),
+            ])
+            body.credentialData = data
+            body.outOfBandId = connectionRecord?.outOfBandId ?? null
+          }
+        } catch (error) {
+          agent.config.logger.error(
+            `Failed to get credential format data for record ${record.id}, continuing with base record`,
+            { cause: error },
           )
-        } else {
-          connectionRecord = await agent.modules.didcomm.connections.findById(record.connectionId)
+          body.credentialData = null
+          body.outOfBandId = null
         }
-        body.outOfBandId = connectionRecord?.outOfBandId
       }
-
-      let formatData = null
-      if (tenantId && tenantId !== 'default') {
-        await (agent as Agent<RestMultiTenantAgentModules>).modules.tenants.withTenantAgent(
-          { tenantId: body.contextCorrelationId as string },
-          async (tenantAgent) => {
-            formatData = await tenantAgent.modules.didcomm.credentials.getFormatData(record.id)
-          },
-        )
-      } else {
-        formatData = await agent.modules.didcomm.credentials.getFormatData(record.id)
-      }
-
-      body.credentialData = formatData
 
       if (config.webhookUrl) {
-        await sendWebhookEvent(config.webhookUrl + '/credentials', body, agent.config.logger)
+        void sendWebhookEvent(config.webhookUrl + '/credentials', body, agent.config.logger)
       }
 
       if (config.socketServer) {

--- a/src/events/ProofEvents.ts
+++ b/src/events/ProofEvents.ts
@@ -3,7 +3,7 @@ import type { ServerConfig } from '../utils/ServerConfig'
 import type { Agent } from '@credo-ts/core'
 import type { DidCommProofStateChangedEvent } from '@credo-ts/didcomm'
 
-import { DidCommProofEventTypes } from '@credo-ts/didcomm'
+import { DidCommProofEventTypes, DidCommProofState } from '@credo-ts/didcomm'
 
 import { sendWebSocketEvent } from './WebSocketEvents'
 import { sendWebhookEvent } from './WebhookEvent'
@@ -23,20 +23,32 @@ export const proofEvents = async (agent: Agent, config: ServerConfig) => {
       proofData: null,
     }
 
-    if (tenantId && tenantId !== 'default') {
-      await (agent as Agent<RestMultiTenantAgentModules>).modules.tenants.withTenantAgent(
-        { tenantId },
-        async (tenantAgent) => {
-          body.proofData = await tenantAgent.modules.didcomm.proofs.getFormatData(record.id)
-        },
-      )
-    } else if (tenantId === 'default') {
-      body.proofData = await agent.modules.didcomm.proofs.getFormatData(record.id)
+    if (record.state === DidCommProofState.Done) {
+      try {
+        if (tenantId && tenantId !== 'default') {
+          await (agent as Agent<RestMultiTenantAgentModules>).modules.tenants.withTenantAgent(
+            { tenantId },
+            async (tenantAgent) => {
+              body.proofData = await tenantAgent.modules.didcomm.proofs.getFormatData(record.id)
+            },
+          )
+        } else if (tenantId === 'default') {
+          body.proofData = await agent.modules.didcomm.proofs.getFormatData(record.id)
+        }
+      } catch (error) {
+        agent.config.logger.error(
+          `Failed to get proof format data for record ${record.id}, continuing with base record`,
+          {
+            cause: error,
+          },
+        )
+        body.proofData = null
+      }
     }
 
     // Only send webhook if webhook url is configured
     if (config.webhookUrl) {
-      await sendWebhookEvent(config.webhookUrl + '/proofs', body, agent.config.logger)
+      void sendWebhookEvent(config.webhookUrl + '/proofs', body, agent.config.logger)
     }
 
     if (config.socketServer) {

--- a/src/events/QuestionAnswerEvents.ts
+++ b/src/events/QuestionAnswerEvents.ts
@@ -16,7 +16,7 @@ export const questionAnswerEvents = async (agent: Agent, config: ServerConfig) =
 
       // Only send webhook if webhook url is configured
       if (config.webhookUrl) {
-        await sendWebhookEvent(config.webhookUrl + '/question-answer', body, agent.config.logger)
+        void sendWebhookEvent(config.webhookUrl + '/question-answer', body, agent.config.logger)
       }
 
       if (config.socketServer) {

--- a/src/events/ReuseConnectionEvents.ts
+++ b/src/events/ReuseConnectionEvents.ts
@@ -18,7 +18,7 @@ export const reuseConnectionEvents = async (agent: Agent, config: ServerConfig) 
 
     // Only send webhook if webhook url is configured
     if (config.webhookUrl) {
-      await sendWebhookEvent(config.webhookUrl + '/connections', body, agent.config.logger)
+      void sendWebhookEvent(config.webhookUrl + '/connections', body, agent.config.logger)
     }
 
     if (config.socketServer) {


### PR DESCRIPTION
## [General] Gate event format-data on Done + fire-and-forget webhook emission

Re-applies the two residual deltas of pipeline-implementation **#38** ("streamline proof/credential data retrieval + webhook event emission") — **General** workstream, Phase A. The core of #38 (per-context `getFormatData`, `null` defaults, `withTenantAgent`) is already upstream on develop; only these were missing:

### Changes
- **State gate** — `ProofEvents`/`CredentialEvents` now fetch `getFormatData` (and, for credentials, the `outOfBand` connection lookup, via `Promise.all`) **only when the record state is `Done`**, wrapped in `try/catch` so a retrieval failure degrades to the base record (`proofData`/`credentialData`/`outOfBandId` = `null`) instead of dropping the webhook. Avoids a per-state-change `getFormatData`/`withTenantAgent` spin-up on intermediate states.
- **Fire-and-forget emission** — webhook emission is `void`-ed rather than `await`ed in the proof, credential, basic-message, connection, question-answer and reuse-connection handlers, so the handler doesn't block on webhook delivery. `sendWebhookEvent` already catches and logs its own errors internally.

### Webhook-contract note (for platform reviewers)
On **non-`Done`** proof/credential states, `proofData`/`credentialData` (and credential `outOfBandId`) are now `null` in the webhook payload. Confirm no platform consumer relies on format data for intermediate states.

### Excluded from this PR
- #38's `cliAgent.ts` session-limit tuning (`Infinity` → `10000`/`10`) — a separate operational concern; the session-leak it addressed is already handled on develop via `withTenantAgent`.
- `openid4vc` event handlers left `await`ed (out of #38's scope; OIDC unused in production).

### Verification
- `yarn check-types`: 0 errors. ESLint (flat config) on all 6 files: clean. Prettier: clean.

Base: `develop`
