### PR TITLE
[General] feat: cache external JSON-LD documents in the document loader (#42)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -25,6 +25,12 @@ FILE_SERVER_TOKEN=
 RPC_URL=
 # Specify server url
 SERVER_URL=
+# JSON-LD document-loader cache (external @context/schema documents).
+# TTL in seconds; defaults to 604800 (7 days) when unset.
+DOCUMENT_LOADER_CACHE_TTL_SECONDS=604800
+# URL prefix whose documents are cached; falls back to SERVER_URL. Caching is
+# disabled (pass-through) when neither is set.
+DOCUMENT_LOADER_CACHE_URL_PREFIX=
 # Specify windowMs
 windowMs=
 # Specify maxRateLimit

--- a/src/cliAgent.ts
+++ b/src/cliAgent.ts
@@ -75,10 +75,9 @@ import {
 } from './purge/PurgeSchedulerFactory'
 import { buildPurgeConfig } from './purge/PurgeTypes'
 import { setupServer } from './server'
+import { CachedDocumentLoader } from './utils/CachedDocumentLoader'
 import { RedisCache } from './utils/RedisCache'
 import { AuthTypes, getAuthType } from './utils/auth'
-import { isCustomDocumentLoaderEnabled } from './utils/config'
-import { CustomDocumentLoader } from './utils/customDocumentLoader'
 import { generateSecretKey } from './utils/helpers'
 import { TsLogger } from './utils/logger'
 import {
@@ -225,11 +224,9 @@ const getModules = (
       registries: [new IndyVdrAnonCredsRegistry()],
       anoncreds,
     }),
-    w3cCredentials: isCustomDocumentLoaderEnabled()
-      ? new W3cCredentialsModule({
-          documentLoader: CustomDocumentLoader,
-        })
-      : new W3cCredentialsModule(),
+    w3cCredentials: new W3cCredentialsModule({
+      documentLoader: CachedDocumentLoader,
+    }),
     didcomm: new DidCommModule({
       processDidCommMessagesConcurrently: true,
       mediationRecipient: true,

--- a/src/utils/CachedDocumentLoader.ts
+++ b/src/utils/CachedDocumentLoader.ts
@@ -1,0 +1,88 @@
+import type { AgentContext, DocumentLoader } from '@credo-ts/core'
+import type { DocumentLoaderResult } from '@credo-ts/core/build/modules/vc/data-integrity/jsonldUtil.mjs'
+
+import { CacheModuleConfig } from '@credo-ts/core'
+import { defaultDocumentLoader } from '@credo-ts/core/build/modules/vc/data-integrity/libraries/documentLoader.mjs'
+
+import { isCustomDocumentLoaderEnabled } from './config'
+import { CustomDocumentLoader } from './customDocumentLoader'
+
+const CACHE_KEY_PREFIX = 'jsonld:document:'
+const DEFAULT_TTL_SECONDS = 60 * 60 * 24 * 7 // 7 days
+
+/**
+ * Cache TTL for JSON-LD documents, in seconds. Configurable via
+ * DOCUMENT_LOADER_CACHE_TTL_SECONDS; defaults to 7 days.
+ */
+const getCacheTtlSeconds = (): number => {
+  const parsed = Number(process.env.DOCUMENT_LOADER_CACHE_TTL_SECONDS)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_TTL_SECONDS
+}
+
+/**
+ * URLs whose documents are cached — the schema host serving external @context
+ * files. Configurable via DOCUMENT_LOADER_CACHE_URL_PREFIX, falling back to
+ * SERVER_URL. When neither is set, caching is disabled (the loader passes
+ * straight through to the underlying loader).
+ */
+const getCacheableUrlPrefix = (): string | undefined =>
+  process.env.DOCUMENT_LOADER_CACHE_URL_PREFIX || process.env.SERVER_URL || undefined
+
+/**
+ * Document loader that adds a cache layer over the active loader — the custom
+ * domain-rewriting loader when ENABLE_CUSTOM_DOCUMENT_LOADER is set, otherwise
+ * Credo's default. External JSON-LD @context / schema documents served from the
+ * schema host are cached in the configured CacheModule cache (Redis when
+ * configured, in-memory otherwise) so W3C verification does not hit the live
+ * host on every request. Cache errors degrade gracefully to a direct fetch.
+ */
+export const CachedDocumentLoader = (agentContext: AgentContext): DocumentLoader => {
+  const logger = agentContext.config.logger
+  const innerLoader = isCustomDocumentLoaderEnabled()
+    ? CustomDocumentLoader(agentContext)
+    : defaultDocumentLoader(agentContext)
+  const cacheableUrlPrefix = getCacheableUrlPrefix()
+  const ttlSeconds = getCacheTtlSeconds()
+
+  return async (url: string): Promise<DocumentLoaderResult> => {
+    // Only cache external documents from the schema host; bundled contexts and
+    // DIDs go straight to the underlying loader.
+    if (!cacheableUrlPrefix || !url.startsWith(cacheableUrlPrefix)) {
+      return innerLoader(url)
+    }
+
+    const cacheKey = `${CACHE_KEY_PREFIX}${url}`
+
+    try {
+      const cache = agentContext.dependencyManager.resolve(CacheModuleConfig).cache
+      const cached = await cache.get<DocumentLoaderResult>(agentContext, cacheKey)
+      if (cached) {
+        logger.debug(`Document loader cache hit: ${url}`)
+        return cached
+      }
+    } catch (error) {
+      logger.warn(`Document loader cache unavailable for ${url}: ${error}`)
+    }
+
+    const document = await innerLoader(url)
+
+    try {
+      const cache = agentContext.dependencyManager.resolve(CacheModuleConfig).cache
+      await cache.set(
+        agentContext,
+        cacheKey,
+        {
+          contextUrl: document.contextUrl,
+          documentUrl: document.documentUrl,
+          document: document.document,
+        },
+        ttlSeconds,
+      )
+      logger.debug(`Document loader cached (${ttlSeconds}s): ${url}`)
+    } catch (error) {
+      logger.warn(`Failed to cache document for ${url}: ${error}`)
+    }
+
+    return document
+  }
+}


### PR DESCRIPTION
## [General] Cache external JSON-LD documents in the credential document loader

Re-applies pipeline-implementation **#42** onto the v2.2.0 baseline — **General** workstream, Phase A. Re-introduces the document-loader caching that **§12.4 / open Q14** flagged as lost on the new baseline (main's loader doesn't cache, so every W3C verification hits the live schema host).

### What it does
New `src/utils/CachedDocumentLoader.ts` layers a cache **over the existing loader**:
- inner loader = `CustomDocumentLoader` (domain-rewriting) when `ENABLE_CUSTOM_DOCUMENT_LOADER` is set, else Credo's `defaultDocumentLoader` — so caching composes with, rather than replaces, the §12.4 domain rewrite.
- `@context`/schema documents from the schema host are cached in the `CacheModule` cache (Redis when configured via #39/#59, in-memory otherwise); bundled contexts and DIDs bypass the cache.
- Cache read/write failures **degrade to a direct fetch** (never block verification).

### Config (env-driven, per request)
- `DOCUMENT_LOADER_CACHE_TTL_SECONDS` — TTL, **default 604800 (7 days)**. Extracted to `.env` so it can be tuned; schema docs rarely change so 7 days is the default.
- `DOCUMENT_LOADER_CACHE_URL_PREFIX` — which URLs to cache; falls back to `SERVER_URL`. Caching is disabled (pass-through) when neither is set.
- `.env.sample` updated.

### Notes
- `cliAgent` now always wires this loader into `W3cCredentialsModule` (previously: `CustomDocumentLoader` only when enabled, else default — both behaviours are preserved as the inner loader).
- **Propagation caveat:** a 7-day TTL means schema-document changes take up to the TTL to propagate; lower `DOCUMENT_LOADER_CACHE_TTL_SECONDS` if a schema host changes contexts frequently.
- Uses `agentContext.config.logger` internally — no logger threading, so this does not depend on #59.

### Verification
- `yarn check-types`: 0 errors. ESLint (flat config) on changed files: clean. Prettier: clean.
- Reviewer note: worth a verification smoke test (verify a JSON-LD credential twice → second resolves from cache; confirm a cache-miss still verifies).

Base: `develop`
