### PR TITLE
[General] test(events): align proof/credential webhook specs with Done-gated payloads

### DIFF
--- a/src/events/__tests__/CredentialEvents.spec.ts
+++ b/src/events/__tests__/CredentialEvents.spec.ts
@@ -1,0 +1,240 @@
+/**
+ * Regression tests for CredentialEvents.ts. Locks in:
+ *
+ *   1. Tenant-session-leak fix — the tenant format-data / connection lookup goes through
+ *      withTenantAgent() (session scoped to the callback, released on exit), never getTenantAgent().
+ *
+ *   2. #61 event refactor — the webhook/socket payload gates `credentialData` and `outOfBandId` on
+ *      the terminal `Done` state: both are `null` (and no getFormatData / findById call is made) for
+ *      every non-Done state, and only populated on `Done`. Webhook emission is fire-and-forget.
+ *
+ * Runs under Jest ESM mode (see jest.config.base.ts). WebhookEvent and WebSocketEvents are stubbed
+ * so no network I/O occurs.
+ */
+import { jest } from '@jest/globals'
+
+jest.unstable_mockModule('../WebhookEvent', () => ({
+  sendWebhookEvent: jest.fn(async () => {}),
+}))
+
+jest.unstable_mockModule('../WebSocketEvents', () => ({
+  sendWebSocketEvent: jest.fn(),
+}))
+
+const { credentialEvents } = await import('../CredentialEvents')
+const { sendWebhookEvent } = await import('../WebhookEvent')
+const { sendWebSocketEvent } = await import('../WebSocketEvents')
+const { DidCommCredentialState } = await import('@credo-ts/didcomm')
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const TENANT_FORMAT_DATA = { credential: 'tenant-credential' }
+const DEFAULT_FORMAT_DATA = { credential: 'default-credential' }
+const TENANT_OOB_ID = 'oob-tenant'
+const DEFAULT_OOB_ID = 'oob-default'
+const WEBHOOK_URL = 'http://example.com/webhook'
+const DONE = DidCommCredentialState.Done
+const NON_DONE = DidCommCredentialState.CredentialReceived // any pre-terminal state
+
+// The handler reads `record.state` (property) for the gate and spreads `record.toJSON()` into the
+// body, so both carry the same state.
+function makeCredentialEvent(contextCorrelationId: string | undefined, state: string = NON_DONE) {
+  return {
+    metadata: { contextCorrelationId },
+    payload: {
+      credentialExchangeRecord: {
+        id: 'cred-record-id',
+        state,
+        connectionId: 'conn-1',
+        toJSON: () => ({ id: 'cred-record-id', state }),
+      },
+    },
+  }
+}
+
+type TenantAgent = {
+  modules: {
+    didcomm: {
+      credentials: { getFormatData: jest.Mock }
+      connections: { findById: jest.Mock }
+    }
+  }
+}
+
+const makeTenantAgent = (formatData: unknown, oobId: string): TenantAgent => ({
+  modules: {
+    didcomm: {
+      credentials: { getFormatData: jest.fn(async () => formatData) as jest.Mock },
+      connections: { findById: jest.fn(async () => ({ outOfBandId: oobId })) as jest.Mock },
+    },
+  },
+})
+
+type MockAgent = {
+  events: { on: jest.Mock }
+  modules: {
+    tenants: { withTenantAgent: jest.Mock; getTenantAgent: jest.Mock }
+    didcomm: {
+      credentials: { getFormatData: jest.Mock }
+      connections: { findById: jest.Mock }
+    }
+  }
+  config: { logger: { info: jest.Mock; warn: jest.Mock; error: jest.Mock; debug: jest.Mock } }
+}
+
+const makeAgent = (): MockAgent => ({
+  events: { on: jest.fn() },
+  modules: {
+    tenants: {
+      withTenantAgent: jest.fn(async ({ tenantId }: { tenantId: string }, cb: (a: TenantAgent) => Promise<void>) => {
+        await cb(makeTenantAgent(TENANT_FORMAT_DATA, TENANT_OOB_ID))
+      }) as jest.Mock,
+      // Deliberately present so we can assert it is NEVER called.
+      getTenantAgent: jest.fn(),
+    },
+    didcomm: {
+      credentials: { getFormatData: jest.fn(async () => DEFAULT_FORMAT_DATA) as jest.Mock },
+      connections: { findById: jest.fn(async () => ({ outOfBandId: DEFAULT_OOB_ID })) as jest.Mock },
+    },
+  },
+  config: {
+    logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+  },
+})
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('credentialEvents', () => {
+  let agent: MockAgent
+  let capturedListener: (event: ReturnType<typeof makeCredentialEvent>) => Promise<void>
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    agent = makeAgent()
+    agent.events.on.mockImplementation((_eventType, listener) => {
+      capturedListener = listener as typeof capturedListener
+    })
+    await credentialEvents(agent as never, { port: 3000, webhookUrl: WEBHOOK_URL })
+  })
+
+  it('registers a listener for DidCommCredentialStateChanged', () => {
+    expect(agent.events.on).toHaveBeenCalledWith('DidCommCredentialStateChanged', expect.any(Function))
+  })
+
+  describe('gate: non-Done state (credential-received)', () => {
+    it('tenant — emits null credentialData/outOfBandId and never fetches format data', async () => {
+      await capturedListener(makeCredentialEvent('tenant-abc123', NON_DONE))
+
+      expect(agent.modules.tenants.withTenantAgent).not.toHaveBeenCalled()
+      expect(agent.modules.tenants.getTenantAgent).not.toHaveBeenCalled()
+      expect(jest.mocked(sendWebhookEvent)).toHaveBeenCalledWith(
+        `${WEBHOOK_URL}/credentials`,
+        expect.objectContaining({ credentialData: null, outOfBandId: null }),
+        expect.anything(),
+      )
+    })
+
+    it('default — emits null credentialData/outOfBandId and does not call getFormatData/findById', async () => {
+      await capturedListener(makeCredentialEvent('default', NON_DONE))
+
+      expect(agent.modules.didcomm.credentials.getFormatData).not.toHaveBeenCalled()
+      expect(agent.modules.didcomm.connections.findById).not.toHaveBeenCalled()
+      expect(jest.mocked(sendWebhookEvent)).toHaveBeenCalledWith(
+        `${WEBHOOK_URL}/credentials`,
+        expect.objectContaining({ credentialData: null, outOfBandId: null }),
+        expect.anything(),
+      )
+    })
+  })
+
+  describe('Done state — tenant event (contextCorrelationId = "tenant-abc123")', () => {
+    beforeEach(async () => {
+      await capturedListener(makeCredentialEvent('tenant-abc123', DONE))
+    })
+
+    it('uses withTenantAgent to scope the session — never getTenantAgent', () => {
+      expect(agent.modules.tenants.withTenantAgent).toHaveBeenCalledTimes(1)
+      expect(agent.modules.tenants.getTenantAgent).not.toHaveBeenCalled()
+    })
+
+    it('strips the "tenant-" prefix before passing tenantId to withTenantAgent', () => {
+      expect(agent.modules.tenants.withTenantAgent).toHaveBeenCalledWith({ tenantId: 'abc123' }, expect.any(Function))
+    })
+
+    it('emits the webhook payload with credentialData and outOfBandId populated', () => {
+      expect(jest.mocked(sendWebhookEvent)).toHaveBeenCalledWith(
+        `${WEBHOOK_URL}/credentials`,
+        expect.objectContaining({ credentialData: TENANT_FORMAT_DATA, outOfBandId: TENANT_OOB_ID }),
+        expect.anything(),
+      )
+    })
+
+    it('does not call the default-agent getFormatData', () => {
+      expect(agent.modules.didcomm.credentials.getFormatData).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Done state — default agent event (contextCorrelationId = "default")', () => {
+    beforeEach(async () => {
+      await capturedListener(makeCredentialEvent('default', DONE))
+    })
+
+    it('calls getFormatData and connections.findById directly', () => {
+      expect(agent.modules.didcomm.credentials.getFormatData).toHaveBeenCalledWith('cred-record-id')
+      expect(agent.modules.didcomm.connections.findById).toHaveBeenCalledWith('conn-1')
+    })
+
+    it('does not open a tenant session', () => {
+      expect(agent.modules.tenants.withTenantAgent).not.toHaveBeenCalled()
+      expect(agent.modules.tenants.getTenantAgent).not.toHaveBeenCalled()
+    })
+
+    it('emits the webhook payload with credentialData and outOfBandId populated', () => {
+      expect(jest.mocked(sendWebhookEvent)).toHaveBeenCalledWith(
+        `${WEBHOOK_URL}/credentials`,
+        expect.objectContaining({ credentialData: DEFAULT_FORMAT_DATA, outOfBandId: DEFAULT_OOB_ID }),
+        expect.anything(),
+      )
+    })
+  })
+
+  describe('webhook and socket emission', () => {
+    it('skips the webhook when webhookUrl is not configured', async () => {
+      await credentialEvents(agent as never, { port: 3000 })
+      await capturedListener(makeCredentialEvent('default', DONE))
+
+      expect(jest.mocked(sendWebhookEvent)).not.toHaveBeenCalled()
+    })
+
+    it('emits a socket event when socketServer is configured', async () => {
+      const socketServer = {} as never
+      await credentialEvents(agent as never, { port: 3000, webhookUrl: WEBHOOK_URL, socketServer })
+      await capturedListener(makeCredentialEvent('default', DONE))
+
+      expect(jest.mocked(sendWebSocketEvent)).toHaveBeenCalledWith(
+        socketServer,
+        expect.objectContaining({
+          payload: expect.objectContaining({
+            credentialRecord: expect.objectContaining({ credentialData: DEFAULT_FORMAT_DATA }),
+          }),
+        }),
+      )
+    })
+
+    it('skips the socket event when socketServer is not configured', async () => {
+      await capturedListener(makeCredentialEvent('default', DONE))
+
+      expect(jest.mocked(sendWebSocketEvent)).not.toHaveBeenCalled()
+    })
+
+    it('is fire-and-forget — the handler resolves without awaiting the webhook', async () => {
+      jest.mocked(sendWebhookEvent).mockImplementationOnce(() => new Promise<void>(() => {}))
+
+      await expect(capturedListener(makeCredentialEvent('default', DONE))).resolves.toBeUndefined()
+    })
+  })
+})

--- a/src/events/__tests__/ProofEvents.spec.ts
+++ b/src/events/__tests__/ProofEvents.spec.ts
@@ -1,12 +1,12 @@
 /**
- * Regression tests for the tenant-session-leak fix in ProofEvents.ts.
+ * Regression tests for ProofEvents.ts. Two behaviours are locked in here:
  *
- * The core regression: getTenantAgent() acquires a wallet session without ever releasing it.
- * withTenantAgent() scopes the session to the callback and releases it on exit — including on
- * error. These tests lock that in so an accidental revert surfaces immediately.
+ *   1. Tenant-session-leak fix — the tenant format-data fetch goes through withTenantAgent()
+ *      (session scoped to the callback and released on exit), never getTenantAgent().
  *
- * Also verifies that the webhook/socket payload is populated with proofData for both the tenant
- * and dedicated-agent code paths.
+ *   2. #61 event refactor — the webhook/socket payload gates `proofData` on the terminal `Done`
+ *      state: it is `null` (and no getFormatData call is made) for every non-Done state, and only
+ *      populated on `Done`. Webhook emission is fire-and-forget (not awaited).
  *
  * Runs under Jest ESM mode (see jest.config.base.ts) because the event module's dependency graph
  * is native ESM. WebhookEvent and WebSocketEvents are stubbed so no network I/O occurs.
@@ -24,6 +24,7 @@ jest.unstable_mockModule('../WebSocketEvents', () => ({
 const { proofEvents } = await import('../ProofEvents')
 const { sendWebhookEvent } = await import('../WebhookEvent')
 const { sendWebSocketEvent } = await import('../WebSocketEvents')
+const { DidCommProofState } = await import('@credo-ts/didcomm')
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -32,14 +33,19 @@ const { sendWebSocketEvent } = await import('../WebSocketEvents')
 const TENANT_FORMAT_DATA = { presentation: 'tenant-presentation' }
 const DEFAULT_FORMAT_DATA = { presentation: 'default-presentation' }
 const WEBHOOK_URL = 'http://example.com/webhook'
+const DONE = DidCommProofState.Done
+const NON_DONE = DidCommProofState.PresentationReceived // any pre-terminal state
 
-function makeProofEvent(contextCorrelationId: string | undefined) {
+// The handler reads `record.state` (property) for the gate and spreads `record.toJSON()` into the
+// body, so both carry the same state.
+function makeProofEvent(contextCorrelationId: string | undefined, state: string = NON_DONE) {
   return {
     metadata: { contextCorrelationId },
     payload: {
       proofRecord: {
         id: 'proof-record-id',
-        toJSON: () => ({ id: 'proof-record-id', state: 'presentation-received' }),
+        state,
+        toJSON: () => ({ id: 'proof-record-id', state }),
       },
     },
   }
@@ -101,9 +107,34 @@ describe('proofEvents', () => {
     expect(agent.events.on).toHaveBeenCalledWith('DidCommProofStateChanged', expect.any(Function))
   })
 
-  describe('tenant event — contextCorrelationId = "tenant-abc123"', () => {
+  describe('gate: non-Done state (presentation-received)', () => {
+    it('tenant — emits proofData: null and never fetches format data', async () => {
+      await capturedListener(makeProofEvent('tenant-abc123', NON_DONE))
+
+      expect(agent.modules.tenants.withTenantAgent).not.toHaveBeenCalled()
+      expect(agent.modules.tenants.getTenantAgent).not.toHaveBeenCalled()
+      expect(jest.mocked(sendWebhookEvent)).toHaveBeenCalledWith(
+        `${WEBHOOK_URL}/proofs`,
+        expect.objectContaining({ proofData: null }),
+        expect.anything(),
+      )
+    })
+
+    it('default — emits proofData: null and does not call getFormatData', async () => {
+      await capturedListener(makeProofEvent('default', NON_DONE))
+
+      expect(agent.modules.didcomm.proofs.getFormatData).not.toHaveBeenCalled()
+      expect(jest.mocked(sendWebhookEvent)).toHaveBeenCalledWith(
+        `${WEBHOOK_URL}/proofs`,
+        expect.objectContaining({ proofData: null }),
+        expect.anything(),
+      )
+    })
+  })
+
+  describe('Done state — tenant event (contextCorrelationId = "tenant-abc123")', () => {
     beforeEach(async () => {
-      await capturedListener(makeProofEvent('tenant-abc123'))
+      await capturedListener(makeProofEvent('tenant-abc123', DONE))
     })
 
     it('uses withTenantAgent to scope the session — never getTenantAgent', () => {
@@ -128,9 +159,9 @@ describe('proofEvents', () => {
     })
   })
 
-  describe('default agent event — contextCorrelationId = "default"', () => {
+  describe('Done state — default agent event (contextCorrelationId = "default")', () => {
     beforeEach(async () => {
-      await capturedListener(makeProofEvent('default'))
+      await capturedListener(makeProofEvent('default', DONE))
     })
 
     it('calls agent.modules.didcomm.proofs.getFormatData directly', () => {
@@ -154,7 +185,7 @@ describe('proofEvents', () => {
   describe('webhook and socket emission', () => {
     it('skips the webhook when webhookUrl is not configured', async () => {
       await proofEvents(agent as never, { port: 3000 })
-      await capturedListener(makeProofEvent('default'))
+      await capturedListener(makeProofEvent('default', DONE))
 
       expect(jest.mocked(sendWebhookEvent)).not.toHaveBeenCalled()
     })
@@ -162,7 +193,7 @@ describe('proofEvents', () => {
     it('emits a socket event when socketServer is configured', async () => {
       const socketServer = {} as never
       await proofEvents(agent as never, { port: 3000, webhookUrl: WEBHOOK_URL, socketServer })
-      await capturedListener(makeProofEvent('default'))
+      await capturedListener(makeProofEvent('default', DONE))
 
       expect(jest.mocked(sendWebSocketEvent)).toHaveBeenCalledWith(
         socketServer,
@@ -175,9 +206,16 @@ describe('proofEvents', () => {
     })
 
     it('skips the socket event when socketServer is not configured', async () => {
-      await capturedListener(makeProofEvent('default'))
+      await capturedListener(makeProofEvent('default', DONE))
 
       expect(jest.mocked(sendWebSocketEvent)).not.toHaveBeenCalled()
+    })
+
+    it('is fire-and-forget — the handler resolves without awaiting the webhook', async () => {
+      // A webhook that never settles must not block the handler (emission uses `void`).
+      jest.mocked(sendWebhookEvent).mockImplementationOnce(() => new Promise<void>(() => {}))
+
+      await expect(capturedListener(makeProofEvent('default', DONE))).resolves.toBeUndefined()
     })
   })
 })


### PR DESCRIPTION
## Why
`#61` (event refactor, already merged) changed the proof/credential webhook payload so `proofData`/`credentialData` (and `outOfBandId`) are **null unless the record's state is `Done`**. But it left `ProofEvents.spec.ts` asserting the *old* contract (data populated at `presentation-received`), so that spec is currently **red on `develop`** (6/11 failing). `CredentialEvents.ts` got the identical change with **no** spec at all.

This is a **verification-only** change (no runtime code touched) — it makes the low-setup unit path for #61 green and pins the gate so a regression surfaces immediately.

## Changes
- **`ProofEvents.spec.ts`** — rewritten to the current contract; the mock record now carries a real `state` property (the handler gates on `record.state === Done`, which the old mock never set).
- **`CredentialEvents.spec.ts`** — new, mirrors it (also covers the `outOfBandId` connection lookup done via `Promise.all` on the `Done` path).

Both cover:
- **Gate:** non-`Done` state → payload `*Data`/`outOfBandId` = `null` **and** no `getFormatData`/`findById` call.
- **`Done`:** populated — tenant path via `withTenantAgent` (never `getTenantAgent`, `tenant-` prefix stripped), default path via the direct modules.
- **Fire-and-forget:** a never-settling webhook mock does not block the handler (emission uses `void`).
- Retains the original tenant-session-leak assertions (withTenantAgent vs getTenantAgent).

## Verification
- `yarn test Events.spec` → **28/28 passing** (2 suites).
- `yarn check-types:test` ✓, ESLint 0 problems.

Note: this validates the agent-side gate. The cross-repo consumer-tolerance check (platform webhook handlers must not NPE on `null` non-terminal payloads) still needs the E2E pass per MERGE-CHECKLIST.