### PR TITLE
[General] ci: run test type-check + jest in the Validate job

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -36,3 +36,9 @@ jobs:
 
       - name: Compile
         run: yarn check-types
+
+      - name: Compile tests
+        run: yarn check-types:test
+
+      - name: Test
+        run: yarn test


### PR DESCRIPTION
## Why
The `Validate` job (the only PR gate) runs `yarn lint`, `yarn check-format`, and `yarn check-types` (`tsconfig.build.json`) — but **never runs jest and never type-checks the specs**. `tsconfig.build.json` explicitly excludes `__tests__/`, and `check-types:test` isn't invoked. So anything under `__tests__/` is invisible to CI: a spec can fail its assertions **or** have type errors and CI still passes green.

That's how #61 merged with `ProofEvents.spec.ts` red — CI never executed it.

## Change
Add two steps to `Validate`:
```yaml
- name: Compile tests
  run: yarn check-types:test
- name: Test
  run: yarn test
```
(`yarn install` already runs patch-package via postinstall; the `test` script already sets `--experimental-vm-modules`, so no extra config is needed.)

## ⚠ Merge order — this is a DRAFT on purpose
**Do not merge before agent-controller PR #66** (`test(events): align proof/credential webhook specs`). `develop`'s `ProofEvents.spec.ts` is currently **red**; #66 makes the full suite green (verified locally: **4 suites / 41 tests pass**, `check-types:test` clean).

Sequence:
1. Merge **#66** → `develop` suite goes green.
2. **Rebase this** on `develop`, mark ready.
3. The Test/Compile-tests steps pass → merge.

Until step 1, this PR's own **Test** check is expected to fail — on exactly the stale spec #66 fixes, which usefully demonstrates the gate now works.