### PR TITLE
fix(purge): stop deleting stored credentials; port batch-tool semantics into the steady-state purge

### DIFF
--- a/.env.demo
+++ b/.env.demo
@@ -112,28 +112,41 @@ INDICIO_TEST_GENESIS='{"reqSignature":{},"txn":{"data":{"data":{"alias":"OpsNode
 {"reqSignature":{},"txn":{"data":{"data":{"alias":"cysecure-itn","blskey":"GdCvMLkkBYevRFi93b6qaj9G2u1W6Vnbg8QhRD1chhrWR8vRE8x9x7KXVeUBPFf6yW5qq2JCfA2frc8SGni2RwjtTagezfwAwnorLhVJqS5ZxTi4pgcw6smebnt4zWVhTkh6ugDHEypHwNQBcw5WhBZcEJKgNbyVLnHok9ob6cfr3u","blskey_pop":"RbH9mY7M5p3UB3oj4sT1skYwMkxjoUnja8eTYfcm83VcNbxC9zR9pCiRhk4q1dJT3wkDBPGNKnk2p83vaJYLcgMuJtzoWoJAWAxjb3Mcq8Agf6cgQpBuzBq2uCzFPuQCAhDS4Kv9iwA6FsRnfvoeFTs1hhgSJVxQzDWMVTVAD9uCqu","client_ip":"35.169.19.171","client_port":"9702","node_ip":"54.225.56.21","node_port":"9701","services":["VALIDATOR"]},"dest":"4ETBDmHzx8iDQB6Xygmo9nNXtMgq9f6hxGArNhQ6Hh3u"},"metadata":{"from":"uSXXXEdBicPHMMhr3ddNF"},"type":"0"},"txnMetadata":{"seqNo":7,"txnId":"3c21718b07806b2f193b35953dda5b68b288efd551dce4467ce890703d5ba549"},"ver":"1"}'
 
 # ─── Data Purge — Record Deletion ────────────────────────────────────────────
-# Automatically deletes credential/proof/session records after a configurable TTL.
-# Two independent flows — enable one or both:
-#   Flow A (NATS): schedules deletion at offer-creation time via NATS JetStream
-#   Flow B (Cron): periodically scans DB and deletes records older than TTL
+# Deletes retention-expired exchange records — the exchange record ONLY. Stored credentials,
+# connections and reusable OOB invitations are never touched.
+#   Flow B (Cron): supported — scans by state, re-checks state at delete time
+#   Flow A (NATS): DEPRECATED — schedules at record creation, so it fires state-blind
 
 PURGE_ENABLED=false
-PURGE_WEBHOOK_ENABLED=false
 
-# ── Flow A: NATS (event-driven, requires NATS connection below) ───────────────
-PURGE_NATS_ENABLED=false
-PURGE_NATS_TTL_SECONDS=2592000
-
-# ── Flow B: Cron (DB scan, no NATS required) ──────────────────────────────────
+# ── Flow B: Cron (DB scan, no NATS required) — the supported flow ──────────────
 PURGE_CRON_ENABLED=false
+# Deletion is opt-in: only the literal "false" arms it. Anything else means dry-run.
+PURGE_CRON_DRY_RUN=true
 PURGE_CRON_TTL_SECONDS=2592000
-PURGE_CRON_SCHEDULE=0 * * * *
+PURGE_CRON_SCHEDULE=0 3 * * *
+PURGE_CRON_BATCH_SIZE=100
+PURGE_CRON_THROTTLE_MS=250
+PURGE_CRON_TIME_BUDGET_MS=0
 
-# ── Optional: per-type record filtering (default: all 4 types) ────────────────
+# ── Optional: stale (non-terminal) PROOF exchanges — never credentials ─────────
+PURGE_CRON_STALE_PROOF_ENABLED=false
+PURGE_CRON_STALE_PROOF_TTL_SECONDS=7776000
+
+# ── Optional: per-type record filtering (default: all 5 types) ────────────────
 # PURGE_DIDCOMM_CREDENTIAL=true
 # PURGE_DIDCOMM_PROOF=true
+# PURGE_DIDCOMM_OOB=true
 # PURGE_OID4VC_ISSUANCE=true
 # PURGE_OID4VC_VERIFICATION=true
+
+# ── Flow A: NATS — DEPRECATED (requires NATS connection below) ────────────────
+PURGE_NATS_ENABLED=false
+PURGE_NATS_TTL_SECONDS=2592000
+PURGE_NATS_ACK_STATE_BLIND=false
+
+# ── DEPRECATED per-record deletion webhook (receiver does not exist) ──────────
+PURGE_WEBHOOK_ENABLED=false
 
 # ─── NATS Connection (required for Flow A) ────────────────────────────────────
 NATS_SERVERS=nats://localhost:4223

--- a/.env.demo
+++ b/.env.demo
@@ -121,8 +121,8 @@ PURGE_ENABLED=false
 
 # ── Flow B: Cron (DB scan, no NATS required) — the supported flow ──────────────
 PURGE_CRON_ENABLED=false
-# Deletion is opt-in: only the literal "false" arms it. Anything else means dry-run.
-PURGE_CRON_DRY_RUN=true
+# Optional census mode — "true" scans and reports without deleting. Must be "true"/"false"/blank.
+PURGE_CRON_DRY_RUN=false
 PURGE_CRON_TTL_SECONDS=2592000
 PURGE_CRON_SCHEDULE=0 3 * * *
 PURGE_CRON_BATCH_SIZE=100

--- a/.env.demo
+++ b/.env.demo
@@ -129,9 +129,10 @@ PURGE_CRON_BATCH_SIZE=100
 PURGE_CRON_THROTTLE_MS=250
 PURGE_CRON_TIME_BUDGET_MS=0
 
-# ── Optional: stale (non-terminal) PROOF exchanges — never credentials ─────────
-PURGE_CRON_STALE_PROOF_ENABLED=false
-PURGE_CRON_STALE_PROOF_TTL_SECONDS=7776000
+# ── Abandoned (dead) records: unanswered proof requests + unscanned OOB ───────
+# Shorter than the terminal TTL by design — a dead request has no value, a completed exchange does.
+PURGE_CRON_ABANDONED_TTL_SECONDS=604800
+PURGE_CRON_STALE_PROOF_ENABLED=true
 
 # ── Optional: per-type record filtering (default: all 5 types) ────────────────
 # PURGE_DIDCOMM_CREDENTIAL=true

--- a/.env.sample
+++ b/.env.sample
@@ -142,17 +142,25 @@ PURGE_CRON_ENABLED=
 # useful once before enabling, to size the eligible set. Leave unset for normal operation.
 # Must be exactly "true", "false" or blank; any other value fails startup.
 PURGE_CRON_DRY_RUN=
-PURGE_CRON_TTL_SECONDS=          # terminal records last updated before this are deleted (default 2592000 = 30 days)
+PURGE_CRON_TTL_SECONDS=          # COMPLETED flows (done/abandoned/declined, OOB done) — default 2592000 = 30 days
 PURGE_CRON_SCHEDULE=             # cron expression for scan frequency (default 0 * * * * = hourly; prefer off-peak)
 PURGE_CRON_BATCH_SIZE=           # records per batch between throttle sleeps (default 100)
 PURGE_CRON_THROTTLE_MS=          # sleep between batches to protect the shared DB pool (default 250; 0 disables)
 PURGE_CRON_TIME_BUDGET_MS=       # per-tenant wall-clock cap; truncated tenants resume next run (default 0 = unlimited)
 
-# ── Optional: stale (non-terminal) PROOF exchanges ────────────────────────────
-# Off by default. Deletes proof exchanges a holder never answered. Never applies to credentials —
-# a holder can still accept a pending offer, so incomplete credential exchanges are never purged.
+# ── Abandoned (dead) records — deliberately a SHORTER TTL than completed ones ─
+# Applies to non-terminal proof exchanges (unanswered proof requests) and to non-reusable
+# await-response OOB invitations (unscanned QR codes / invitation URLs). Neither has any future
+# use, unlike a completed exchange which is an audit record of a verification that happened.
+# In the July 2026 production drain these two were the dominant volume: proof request-sent was
+# ~68% of all proof exchanges, and OOB was the largest purgeable category (~91% of it eligible).
+PURGE_CRON_ABANDONED_TTL_SECONDS=     # default 604800 = 7 days. Floor 3600s.
+# Set to false to stop sweeping non-terminal PROOF exchanges (default true). Never applies to
+# credentials — a holder can still accept a pending offer, so incomplete credential exchanges are
+# never purged at any TTL.
 PURGE_CRON_STALE_PROOF_ENABLED=
-PURGE_CRON_STALE_PROOF_TTL_SECONDS=   # must be >= PURGE_CRON_TTL_SECONDS (default 7776000 = 90 days)
+# Testing only — permits an abandoned TTL below the 3600s floor.
+PURGE_CRON_ALLOW_SHORT_ABANDONED_TTL=
 
 # ── Optional: per-type record filtering ───────────────────────────────────────
 # Uncomment to restrict purge to specific record types (default: all types enabled)

--- a/.env.sample
+++ b/.env.sample
@@ -138,8 +138,9 @@ PURGE_ENABLED=
 
 # ── Flow B: Cron (DB scan, no NATS required) — the supported flow ──────────────
 PURGE_CRON_ENABLED=
-# IMPORTANT: deletion is opt-in. Anything other than the literal "false" (including blank) means
-# dry-run: the job scans and reports a census to the logs but deletes nothing.
+# Optional census mode. Set to "true" to scan and report to the logs without deleting anything —
+# useful once before enabling, to size the eligible set. Leave unset for normal operation.
+# Must be exactly "true", "false" or blank; any other value fails startup.
 PURGE_CRON_DRY_RUN=
 PURGE_CRON_TTL_SECONDS=          # terminal records last updated before this are deleted (default 2592000 = 30 days)
 PURGE_CRON_SCHEDULE=             # cron expression for scan frequency (default 0 * * * * = hourly; prefer off-peak)

--- a/.env.sample
+++ b/.env.sample
@@ -123,31 +123,54 @@ INDICIO_TEST_GENESIS=`{"reqSignature":{},"txn":{"data":{"data":{"alias":"OpsNode
 {"reqSignature":{},"txn":{"data":{"data":{"alias":"lorica-identity-node1","blskey":"wUh24sVCQ8PHDgSb343g2eLxjD5vwxsrETfuV2sbwMNnYon9nhbaK5jcWTekvXtyiwxHxuiCCoZwKS97MQEAeC2oLbbMeKjYm212QwSnm7aKLEqTStXht35VqZvZLT7Q3mPQRYLjMGixdn4ocNHrBTMwPUQYycEqwaHWgE1ncDueXY","blskey_pop":"R2sMwF7UW6AaD4ALa1uB1YVPuP6JsdJ7LsUoViM9oySFqFt34C1x1tdHDysS9wwruzaaEFui6xNPqJ8eu3UBqcFKkoWhdsMqCALwe63ytxPwvtLtCffJLhHAcgrPC7DorXYdqhdG2cevdqc5oqFEAaKoFDBf12p5SsbbM4PYWCmVCb","client_ip":"35.225.220.151","client_port":"9702","node_ip":"35.224.26.110","node_port":"9701","services":["VALIDATOR"]},"dest":"k74ZsZuUaJEcB8RRxMwkCwdE5g1r9yzA3nx41qvYqYf"},"metadata":{"from":"Ex6hzsJFYzNJ7kzbfncNeU"},"type":"0"},"txnMetadata":{"seqNo":6,"txnId":"6880673ce4ae4a2352f103d2a6ae20469dd070f2027283a1da5e62a64a59d688"},"ver":"1"}
 {"reqSignature":{},"txn":{"data":{"data":{"alias":"cysecure-itn","blskey":"GdCvMLkkBYevRFi93b6qaj9G2u1W6Vnbg8QhRD1chhrWR8vRE8x9x7KXVeUBPFf6yW5qq2JCfA2frc8SGni2RwjtTagezfwAwnorLhVJqS5ZxTi4pgcw6smebnt4zWVhTkh6ugDHEypHwNQBcw5WhBZcEJKgNbyVLnHok9ob6cfr3u","blskey_pop":"RbH9mY7M5p3UB3oj4sT1skYwMkxjoUnja8eTYfcm83VcNbxC9zR9pCiRhk4q1dJT3wkDBPGNKnk2p83vaJYLcgMuJtzoWoJAWAxjb3Mcq8Agf6cgQpBuzBq2uCzFPuQCAhDS4Kv9iwA6FsRnfvoeFTs1hhgSJVxQzDWMVTVAD9uCqu","client_ip":"35.169.19.171","client_port":"9702","node_ip":"54.225.56.21","node_port":"9701","services":["VALIDATOR"]},"dest":"4ETBDmHzx8iDQB6Xygmo9nNXtMgq9f6hxGArNhQ6Hh3u"},"metadata":{"from":"uSXXXEdBicPHMMhr3ddNF"},"type":"0"},"txnMetadata":{"seqNo":7,"txnId":"3c21718b07806b2f193b35953dda5b68b288efd551dce4467ce890703d5ba549"},"ver":"1"}`
 # ─── Data Purge ───────────────────────────────────────────────────────────────
-# Automatically deletes records after a configurable TTL.
-# Two independent flows — enable one or both:
-#   Flow A (NATS): schedules deletion at offer-creation time via NATS JetStream
-#   Flow B (Cron): periodically scans DB and deletes records older than TTL
+# Deletes retention-expired exchange records. Only the EXCHANGE record is removed — stored
+# credentials (W3C / AnonCreds), connections, and reusable OOB invitations are never touched.
+#
+# Flow B (Cron) is the supported flow: it re-reads each record's state at delete time, so only
+# terminal (done / abandoned / declined) records past TTL are eligible.
+# Flow A (NATS) is DEPRECATED — it fixes the deletion time when the record is created and so fires
+# without re-checking state. It refuses to start unless PURGE_NATS_ACK_STATE_BLIND=true.
+#
+# Heavy one-off backfills are NOT this job's role — use the operator-run `credo-data-purge` tool.
 
-# Master switch — set to true to activate purge system
+# Master switch — set to true to activate the purge system
 PURGE_ENABLED=
-# Set to false to skip webhook calls after deletion (default: true)
-PURGE_WEBHOOK_ENABLED=
 
-# ── Flow A: NATS (requires NATS_SERVERS below) ────────────────────────────────
-PURGE_NATS_ENABLED=
-PURGE_NATS_TTL_SECONDS=          # seconds from offer creation to deletion (e.g. 2592000 = 30 days)
-
-# ── Flow B: Cron (DB scan, no NATS required) ──────────────────────────────────
+# ── Flow B: Cron (DB scan, no NATS required) — the supported flow ──────────────
 PURGE_CRON_ENABLED=
-PURGE_CRON_TTL_SECONDS=          # records older than this (createdAt) are deleted (e.g. 2592000 = 30 days)
-PURGE_CRON_SCHEDULE=             # cron expression for scan frequency (e.g. 0 * * * * = hourly)
+# IMPORTANT: deletion is opt-in. Anything other than the literal "false" (including blank) means
+# dry-run: the job scans and reports a census to the logs but deletes nothing.
+PURGE_CRON_DRY_RUN=
+PURGE_CRON_TTL_SECONDS=          # terminal records last updated before this are deleted (default 2592000 = 30 days)
+PURGE_CRON_SCHEDULE=             # cron expression for scan frequency (default 0 * * * * = hourly; prefer off-peak)
+PURGE_CRON_BATCH_SIZE=           # records per batch between throttle sleeps (default 100)
+PURGE_CRON_THROTTLE_MS=          # sleep between batches to protect the shared DB pool (default 250; 0 disables)
+PURGE_CRON_TIME_BUDGET_MS=       # per-tenant wall-clock cap; truncated tenants resume next run (default 0 = unlimited)
+
+# ── Optional: stale (non-terminal) PROOF exchanges ────────────────────────────
+# Off by default. Deletes proof exchanges a holder never answered. Never applies to credentials —
+# a holder can still accept a pending offer, so incomplete credential exchanges are never purged.
+PURGE_CRON_STALE_PROOF_ENABLED=
+PURGE_CRON_STALE_PROOF_TTL_SECONDS=   # must be >= PURGE_CRON_TTL_SECONDS (default 7776000 = 90 days)
 
 # ── Optional: per-type record filtering ───────────────────────────────────────
 # Uncomment to restrict purge to specific record types (default: all types enabled)
 # PURGE_DIDCOMM_CREDENTIAL=true
 # PURGE_DIDCOMM_PROOF=true
+# PURGE_DIDCOMM_OOB=true
 # PURGE_OID4VC_ISSUANCE=true
 # PURGE_OID4VC_VERIFICATION=true
+
+# ── Flow A: NATS — DEPRECATED (requires NATS_SERVERS below) ────────────────────
+PURGE_NATS_ENABLED=
+PURGE_NATS_TTL_SECONDS=          # seconds from offer creation to deletion (e.g. 2592000 = 30 days)
+# Required acknowledgement that Flow A deletes records without re-checking their state.
+PURGE_NATS_ACK_STATE_BLIND=
+
+# ── Optional: DEPRECATED per-record deletion webhook ──────────────────────────
+# Off unless set to the literal "true". POSTs to {WEBHOOK_URL}/purge/* — endpoints that do not
+# currently exist on the platform. The per-run audit log is the supported notification surface.
+PURGE_WEBHOOK_ENABLED=
 
 # ─── NATS Connection (required for Flow A) ────────────────────────────────────
 NATS_SERVERS=

--- a/src/purge/PurgeConfigValidator.ts
+++ b/src/purge/PurgeConfigValidator.ts
@@ -14,7 +14,30 @@ export async function validatePurgeConfig(config: PurgeConfig): Promise<void> {
     )
   }
 
+  if (cronConfig.enabled && cronConfig.staleProofEnabled && cronConfig.staleProofTtlSeconds < cronConfig.ttlSeconds) {
+    // The stale-proof policy targets records that are still open, so a TTL shorter than the terminal
+    // one would delete in-flight verifications sooner than completed ones — always a
+    // misconfiguration, and one that silently destroys live flows if allowed through.
+    throw new Error(
+      `[Purge] PURGE_CRON_STALE_PROOF_TTL_SECONDS (${cronConfig.staleProofTtlSeconds}) must be >= ` +
+        `PURGE_CRON_TTL_SECONDS (${cronConfig.ttlSeconds}). Incomplete proof exchanges must never be ` +
+        'purged more aggressively than completed ones.',
+    )
+  }
+
   if (natsConfig.enabled) {
+    // Deprecated flow (INTEGRATION-PLAN-develop.md §4.4). It is kept for reversibility, but enabling
+    // it must be a deliberate, documented act rather than a flag someone flips by analogy with the
+    // cron flow — it deletes without re-checking record state.
+    if (!natsConfig.ackStateBlind) {
+      throw new Error(
+        '[Purge] PURGE_NATS_ENABLED=true is deprecated and refused by default. The NATS ' +
+          'schedule-at-create flow fixes a record’s deletion time when the record is created, so it fires ' +
+          'without re-checking state and can delete exchanges that are still in flight. Use the cron flow ' +
+          '(PURGE_CRON_ENABLED=true), which re-checks state at delete time. To override anyway, set ' +
+          'PURGE_NATS_ACK_STATE_BLIND=true.',
+      )
+    }
     await verifyNatsJetStream(natsConfig.nats)
   }
 }

--- a/src/purge/PurgeConfigValidator.ts
+++ b/src/purge/PurgeConfigValidator.ts
@@ -10,13 +10,6 @@ import { MIN_ABANDONED_TTL_SECONDS } from './PurgeTypes'
 export async function validatePurgeConfig(config: PurgeConfig): Promise<void> {
   const { natsConfig, cronConfig } = config
 
-  if (!natsConfig.enabled && !cronConfig.enabled) {
-    throw new Error(
-      '[Purge] PURGE_ENABLED=true but neither PURGE_NATS_ENABLED nor PURGE_CRON_ENABLED is set to true. ' +
-        'Enable at least one mode.',
-    )
-  }
-
   if (cronConfig.enabled && !cron.validate(cronConfig.cronSchedule)) {
     // node-cron does validate, but only when the task is created, and it fails with a bare
     // "Cannot read properties of undefined (reading 'replace')" that names neither the purge nor the

--- a/src/purge/PurgeConfigValidator.ts
+++ b/src/purge/PurgeConfigValidator.ts
@@ -4,6 +4,8 @@ import { connect } from 'nats'
 
 import { buildNatsAuthenticator } from '../utils/NatsAuthenticator'
 
+import { MIN_ABANDONED_TTL_SECONDS } from './PurgeTypes'
+
 export async function validatePurgeConfig(config: PurgeConfig): Promise<void> {
   const { natsConfig, cronConfig } = config
 
@@ -14,14 +16,19 @@ export async function validatePurgeConfig(config: PurgeConfig): Promise<void> {
     )
   }
 
-  if (cronConfig.enabled && cronConfig.staleProofEnabled && cronConfig.staleProofTtlSeconds < cronConfig.ttlSeconds) {
-    // The stale-proof policy targets records that are still open, so a TTL shorter than the terminal
-    // one would delete in-flight verifications sooner than completed ones — always a
-    // misconfiguration, and one that silently destroys live flows if allowed through.
+  if (
+    cronConfig.enabled &&
+    cronConfig.abandonedTtlSeconds < MIN_ABANDONED_TTL_SECONDS &&
+    !cronConfig.allowShortAbandonedTtl
+  ) {
+    // An absolute floor, NOT a "must be >= the terminal TTL" rule. Abandoned records are expected to
+    // be purged far sooner than completed ones — dead requests have no value where completed
+    // exchanges are audit records. The only real hazard is deleting a flow a holder is still
+    // responding to, which is a minutes-scale window, so the floor guards that and nothing else.
     throw new Error(
-      `[Purge] PURGE_CRON_STALE_PROOF_TTL_SECONDS (${cronConfig.staleProofTtlSeconds}) must be >= ` +
-        `PURGE_CRON_TTL_SECONDS (${cronConfig.ttlSeconds}). Incomplete proof exchanges must never be ` +
-        'purged more aggressively than completed ones.',
+      `[Purge] PURGE_CRON_ABANDONED_TTL_SECONDS (${cronConfig.abandonedTtlSeconds}) is below the ` +
+        `${MIN_ABANDONED_TTL_SECONDS}s floor, which risks deleting flows a holder is still responding to. ` +
+        'Set PURGE_CRON_ALLOW_SHORT_ABANDONED_TTL=true to override (testing only).',
     )
   }
 

--- a/src/purge/PurgeConfigValidator.ts
+++ b/src/purge/PurgeConfigValidator.ts
@@ -1,6 +1,7 @@
 import type { NatsConfig, PurgeConfig } from './PurgeTypes'
 
 import { connect } from 'nats'
+import cron from 'node-cron'
 
 import { buildNatsAuthenticator } from '../utils/NatsAuthenticator'
 
@@ -13,6 +14,16 @@ export async function validatePurgeConfig(config: PurgeConfig): Promise<void> {
     throw new Error(
       '[Purge] PURGE_ENABLED=true but neither PURGE_NATS_ENABLED nor PURGE_CRON_ENABLED is set to true. ' +
         'Enable at least one mode.',
+    )
+  }
+
+  if (cronConfig.enabled && !cron.validate(cronConfig.cronSchedule)) {
+    // node-cron does validate, but only when the task is created, and it fails with a bare
+    // "Cannot read properties of undefined (reading 'replace')" that names neither the purge nor the
+    // schedule — leaving an operator with a crashed agent and no clue why. Fail here instead.
+    throw new Error(
+      `[Purge] PURGE_CRON_SCHEDULE is not a valid cron expression: "${cronConfig.cronSchedule}". ` +
+        'Expected 5 or 6 fields, e.g. "0 3 * * *" for 03:00 daily.',
     )
   }
 

--- a/src/purge/PurgeConstants.ts
+++ b/src/purge/PurgeConstants.ts
@@ -2,10 +2,17 @@ import { PurgeRecordType } from './PurgeTypes'
 
 export const PURGE_STREAM = 'PURGE'
 
+/**
+ * NATS subject / consumer maps for the deprecated schedule-at-create flow
+ * (INTEGRATION-PLAN-develop.md §4.4). `DIDCOMM_OOB` has no schedule-at-create call site — there is
+ * no `@SchedulePurge` on invitation creation — but the maps are `Record<PurgeRecordType, …>`, so
+ * every type needs an entry. Entries exist only to keep the maps exhaustive.
+ */
 // Schedule and execution subjects must be in the same stream for Nats-Schedule-Target to work
 export const PURGE_SCHEDULER_SUBJECTS: Record<PurgeRecordType, string> = {
   [PurgeRecordType.DIDCOMM_CREDENTIAL]: 'purge.schedule.didcomm.credential',
   [PurgeRecordType.DIDCOMM_PROOF]: 'purge.schedule.didcomm.proof',
+  [PurgeRecordType.DIDCOMM_OOB]: 'purge.schedule.didcomm.oob',
   [PurgeRecordType.OID4VC_ISSUANCE]: 'purge.schedule.oid4vc.issuance',
   [PurgeRecordType.OID4VC_VERIFICATION]: 'purge.schedule.oid4vc.verification',
 }
@@ -13,6 +20,7 @@ export const PURGE_SCHEDULER_SUBJECTS: Record<PurgeRecordType, string> = {
 export const PURGE_EXECUTION_SUBJECTS: Record<PurgeRecordType, string> = {
   [PurgeRecordType.DIDCOMM_CREDENTIAL]: 'purge.execute.didcomm.credential',
   [PurgeRecordType.DIDCOMM_PROOF]: 'purge.execute.didcomm.proof',
+  [PurgeRecordType.DIDCOMM_OOB]: 'purge.execute.didcomm.oob',
   [PurgeRecordType.OID4VC_ISSUANCE]: 'purge.execute.oid4vc.issuance',
   [PurgeRecordType.OID4VC_VERIFICATION]: 'purge.execute.oid4vc.verification',
 }
@@ -20,6 +28,7 @@ export const PURGE_EXECUTION_SUBJECTS: Record<PurgeRecordType, string> = {
 export const PURGE_CONSUMER_NAMES: Record<PurgeRecordType, string> = {
   [PurgeRecordType.DIDCOMM_CREDENTIAL]: 'purge-worker-didcomm-credential',
   [PurgeRecordType.DIDCOMM_PROOF]: 'purge-worker-didcomm-proof',
+  [PurgeRecordType.DIDCOMM_OOB]: 'purge-worker-didcomm-oob',
   [PurgeRecordType.OID4VC_ISSUANCE]: 'purge-worker-oid4vc-issuance',
   [PurgeRecordType.OID4VC_VERIFICATION]: 'purge-worker-oid4vc-verification',
 }
@@ -39,6 +48,7 @@ export const PURGE_CONSUMER_BACKOFF_NS = [
 export const PURGE_WEBHOOK_PATHS: Record<PurgeRecordType, string> = {
   [PurgeRecordType.DIDCOMM_CREDENTIAL]: '/purge/didcomm-credential',
   [PurgeRecordType.DIDCOMM_PROOF]: '/purge/didcomm-proof',
+  [PurgeRecordType.DIDCOMM_OOB]: '/purge/didcomm-oob',
   [PurgeRecordType.OID4VC_ISSUANCE]: '/purge/oid4vc-issuance',
   [PurgeRecordType.OID4VC_VERIFICATION]: '/purge/oid4vc-verification',
 }

--- a/src/purge/PurgeDeleteRecord.ts
+++ b/src/purge/PurgeDeleteRecord.ts
@@ -1,40 +1,37 @@
 import type { PurgeRecordType } from './PurgeTypes'
-import type { Agent, BaseRecord, BaseRecordConstructor, StorageService } from '@credo-ts/core'
+import type { Agent } from '@credo-ts/core'
 
-import { InjectionSymbols, RecordNotFoundError } from '@credo-ts/core'
+import { RecordNotFoundError } from '@credo-ts/core'
 import {
-  DidCommCredentialExchangeRecord,
-  DidCommMessageRecord,
-  DidCommOutOfBandRecord,
-  DidCommProofExchangeRecord,
+  DidCommCredentialExchangeRepository,
+  DidCommMessageRepository,
+  DidCommProofExchangeRepository,
 } from '@credo-ts/didcomm'
 import { OpenId4VcIssuanceSessionRepository, OpenId4VcVerificationSessionRepository } from '@credo-ts/openid4vc'
 
 import { PurgeRecordType as RecordType } from './PurgeTypes'
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyRecord = BaseRecord<any, any, any>
-
 /**
- * The exchange record classes deleted at the STORAGE layer.
+ * Deletion is performed at the REPOSITORY layer, never the protocol layer.
  *
- * Why storage-level and not `agent.modules.didcomm.credentials.deleteById(id)`:
- * `DidCommBaseCredentialProtocol.delete()` defaults `deleteAssociatedCredentials` to `true`, so the
- * protocol-level delete also destroys the stored `W3cCredentialRecord` / `AnonCredsCredentialRecord`
- * the exchange produced. For a holder cloud wallet that is data loss — the holder loses the actual
- * credential, not just the (already-completed) exchange bookkeeping. Going through the
- * `StorageService` deletes the parent exchange record and nothing else.
+ * Why not `agent.modules.didcomm.credentials.deleteById(id)`:
+ * `DidCommBaseCredentialProtocol.delete()` defaults `deleteAssociatedCredentials` to `true`, and on
+ * this deployment's format-service ordering that resolves to `legacyIndyCredentialFormat` →
+ * `AnonCredsRsHolderService.deleteCredential()` → `W3cCredentialRepository.delete()`. For a holder
+ * cloud wallet issuing JSON-LD over DIDComm, a routine retention purge would destroy the holder's
+ * actual credential. See `__tests__/PurgeDeleteRecord.spec.ts` and INTEGRATION-PLAN-develop.md §4.1.
  *
- * This mirrors `credo-data-purge`'s "bypass the protocol layer entirely" decision
- * (INTEGRATION-PLAN-develop.md §4.1) and is covered by `__tests__/PurgeDeleteRecord.spec.ts`.
+ * Why the repository rather than the raw `StorageService`: `Repository.deleteById()` is exactly
+ * `storageService.deleteById()` plus a `RepositoryEventTypes.RecordDeleted` emit — no extra read, no
+ * cascade — so it keeps the credential-safety property while preserving the lifecycle event that
+ * every other delete path in Credo produces.
  *
- * DIDComm message children are NOT cascaded by the storage layer, so the purge engine removes them
- * explicitly per parent before deleting the parent — see `deleteDidCommMessageChildren`.
+ * OOB is the one exception and goes through its API on purpose — see `deletePurgeRecord`.
  */
-const STORAGE_LEVEL_RECORD_CLASSES: Partial<Record<PurgeRecordType, BaseRecordConstructor<AnyRecord>>> = {
-  [RecordType.DIDCOMM_CREDENTIAL]: DidCommCredentialExchangeRecord as BaseRecordConstructor<AnyRecord>,
-  [RecordType.DIDCOMM_PROOF]: DidCommProofExchangeRecord as BaseRecordConstructor<AnyRecord>,
-  [RecordType.DIDCOMM_OOB]: DidCommOutOfBandRecord as BaseRecordConstructor<AnyRecord>,
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyRepository = {
+  deleteById(agentContext: any, id: string): Promise<void>
+  findById(agentContext: any, id: string): Promise<any>
 }
 
 /**
@@ -49,42 +46,57 @@ export const RECORD_TYPES_WITH_DIDCOMM_MESSAGE_CHILDREN: ReadonlySet<PurgeRecord
   RecordType.DIDCOMM_PROOF,
 ])
 
-export function resolveStorageService(agent: Agent): StorageService<AnyRecord> {
-  return agent.dependencyManager.resolve<StorageService<AnyRecord>>(InjectionSymbols.StorageService)
+function resolveRepository(agent: Agent, recordType: PurgeRecordType): AnyRepository | undefined {
+  switch (recordType) {
+    case RecordType.DIDCOMM_CREDENTIAL:
+      return agent.dependencyManager.resolve(DidCommCredentialExchangeRepository) as unknown as AnyRepository
+    case RecordType.DIDCOMM_PROOF:
+      return agent.dependencyManager.resolve(DidCommProofExchangeRepository) as unknown as AnyRepository
+    case RecordType.OID4VC_ISSUANCE:
+      return agent.dependencyManager.resolve(OpenId4VcIssuanceSessionRepository) as unknown as AnyRepository
+    case RecordType.OID4VC_VERIFICATION:
+      return agent.dependencyManager.resolve(OpenId4VcVerificationSessionRepository) as unknown as AnyRepository
+    // OOB has no repository branch — it must go through the API for the routing cleanup.
+    default:
+      return undefined
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function oobApi(agent: Agent): any {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (agent as any).modules.didcomm.oob
 }
 
 /** IDs of the `DidCommMessageRecord`s associated with an exchange record. */
 export async function findDidCommMessageChildIds(agent: Agent, parentRecordId: string): Promise<string[]> {
-  const storageService = resolveStorageService(agent)
-  const messages = await storageService.findByQuery(agent.context, DidCommMessageRecord, {
-    associatedRecordId: parentRecordId,
-  })
+  const repository = agent.dependencyManager.resolve(DidCommMessageRepository)
+  const messages = await repository.findByQuery(agent.context, { associatedRecordId: parentRecordId })
   return messages.map((message) => message.id)
 }
 
 /**
  * Delete the `DidCommMessageRecord` children of an exchange record.
  *
- * Callers must run this to completion BEFORE deleting the parent: the storage-level parent delete
- * no longer cascades, so a parent removed while a child delete is still outstanding leaves an
- * orphaned message that only a full-wallet orphan sweep can find. The steady-state job deliberately
- * does not run that sweep (INTEGRATION-PLAN-develop.md §8), so this per-parent cascade is the only
- * thing keeping orphans from accumulating — and that only holds if the ordering is respected.
+ * Callers must run this to completion BEFORE deleting the parent: the parent delete no longer
+ * cascades, so a parent removed while a child delete is still outstanding leaves an orphaned message
+ * that only a full-wallet orphan sweep can find. The steady-state job deliberately does not run that
+ * sweep (INTEGRATION-PLAN-develop.md §8), so this per-parent cascade is the only thing keeping
+ * orphans from accumulating — and that only holds if the ordering is respected.
  *
  * A child that is ALREADY gone is skipped rather than treated as an error: for a delete, "absent" is
  * the desired end state. Letting `RecordNotFoundError` escape here would abort the cascade and, via
  * the caller's error handling, leave the parent undeleted while reporting the record as successfully
- * already-absent — so a wallet with a partially-completed previous run could make only partial
- * progress on every subsequent run while looking healthy.
+ * already-absent.
  *
  * @returns the number of children that are no longer present (deleted here or already gone).
  */
 export async function deleteDidCommMessageChildren(agent: Agent, childIds: string[]): Promise<number> {
-  const storageService = resolveStorageService(agent)
+  const repository = agent.dependencyManager.resolve(DidCommMessageRepository)
   let removed = 0
   for (const childId of childIds) {
     try {
-      await storageService.deleteById(agent.context, DidCommMessageRecord, childId)
+      await repository.deleteById(agent.context, childId)
     } catch (error) {
       // Real failures (lock, I/O) still propagate, so the parent is not deleted and is retried.
       if (!(error instanceof RecordNotFoundError)) throw error
@@ -95,35 +107,43 @@ export async function deleteDidCommMessageChildren(agent: Agent, childIds: strin
 }
 
 /**
+ * Re-read a record immediately before deleting it, so eligibility is decided on its CURRENT state
+ * rather than on the snapshot taken when the page was scanned.
+ *
+ * @returns the record, or undefined if it no longer exists.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function findPurgeRecordById(agent: Agent, recordType: PurgeRecordType, id: string): Promise<any> {
+  if (recordType === RecordType.DIDCOMM_OOB) return oobApi(agent).findById(id)
+
+  const repository = resolveRepository(agent, recordType)
+  if (!repository) throw new Error(`[Purge] No repository for record type: ${recordType}`)
+  return repository.findById(agent.context, id)
+}
+
+/**
  * Delete a single purgeable record — the parent record ONLY.
  *
  * @throws {RecordNotFoundError} if the record is already gone. Callers treat this as an idempotent
  * success: for a delete, "already absent" is the desired end state.
  */
 export async function deletePurgeRecord(agent: Agent, recordType: PurgeRecordType, recordId: string): Promise<void> {
-  const recordClass = STORAGE_LEVEL_RECORD_CLASSES[recordType]
-  if (recordClass) {
-    await resolveStorageService(agent).deleteById(agent.context, recordClass, recordId)
+  if (recordType === RecordType.DIDCOMM_OOB) {
+    // OOB deliberately goes through the API rather than the repository. `DidCommOutOfBandApi
+    // .deleteById()` deregisters the invitation's recipient keys from the mediator first, when the
+    // record has a `mediatorId`, carries only inline services, and has no related connection (or is
+    // reusable). The 7-day `await-response` non-reusable track is exactly that "no related
+    // connection" case, and `create-request-oob` routes through `mediationRecipient.getRouting()`,
+    // so every purged invitation would otherwise leave its recipient keys registered at the mediator
+    // forever. Unlike the credential API, this one cascades nothing else — the hazard that forces
+    // credentials off the protocol layer simply does not exist here.
+    await oobApi(agent).deleteById(recordId)
     return
   }
 
-  switch (recordType) {
-    // The OID4VC repositories are already parent-only — no protocol cascade to bypass.
-    case RecordType.OID4VC_ISSUANCE: {
-      const repo = agent.dependencyManager.resolve(OpenId4VcIssuanceSessionRepository)
-      await repo.deleteById(agent.context, recordId)
-      break
-    }
-
-    case RecordType.OID4VC_VERIFICATION: {
-      const repo = agent.dependencyManager.resolve(OpenId4VcVerificationSessionRepository)
-      await repo.deleteById(agent.context, recordId)
-      break
-    }
-
-    default: {
-      const _exhaustive: never = recordType as never
-      throw new Error(`[Purge] Unhandled record type: ${_exhaustive}`)
-    }
+  const repository = resolveRepository(agent, recordType)
+  if (!repository) {
+    throw new Error(`[Purge] Unhandled record type: ${recordType}`)
   }
+  await repository.deleteById(agent.context, recordId)
 }

--- a/src/purge/PurgeDeleteRecord.ts
+++ b/src/purge/PurgeDeleteRecord.ts
@@ -1,33 +1,112 @@
-import type { Agent } from '@credo-ts/core'
+import type { PurgeRecordType } from './PurgeTypes'
+import type { Agent, BaseRecord, BaseRecordConstructor, StorageService } from '@credo-ts/core'
 
+import { InjectionSymbols } from '@credo-ts/core'
+import {
+  DidCommCredentialExchangeRecord,
+  DidCommMessageRecord,
+  DidCommOutOfBandRecord,
+  DidCommProofExchangeRecord,
+} from '@credo-ts/didcomm'
 import { OpenId4VcIssuanceSessionRepository, OpenId4VcVerificationSessionRepository } from '@credo-ts/openid4vc'
 
-import { PurgeRecordType } from './PurgeTypes'
+import { PurgeRecordType as RecordType } from './PurgeTypes'
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyRecord = BaseRecord<any, any, any>
+
+/**
+ * The exchange record classes deleted at the STORAGE layer.
+ *
+ * Why storage-level and not `agent.modules.didcomm.credentials.deleteById(id)`:
+ * `DidCommBaseCredentialProtocol.delete()` defaults `deleteAssociatedCredentials` to `true`, so the
+ * protocol-level delete also destroys the stored `W3cCredentialRecord` / `AnonCredsCredentialRecord`
+ * the exchange produced. For a holder cloud wallet that is data loss — the holder loses the actual
+ * credential, not just the (already-completed) exchange bookkeeping. Going through the
+ * `StorageService` deletes the parent exchange record and nothing else.
+ *
+ * This mirrors `credo-data-purge`'s "bypass the protocol layer entirely" decision
+ * (INTEGRATION-PLAN-develop.md §4.1) and is covered by `__tests__/PurgeDeleteRecord.spec.ts`.
+ *
+ * DIDComm message children are NOT cascaded by the storage layer, so the purge engine removes them
+ * explicitly per parent before deleting the parent — see `deleteDidCommMessageChildren`.
+ */
+const STORAGE_LEVEL_RECORD_CLASSES: Partial<Record<PurgeRecordType, BaseRecordConstructor<AnyRecord>>> = {
+  [RecordType.DIDCOMM_CREDENTIAL]: DidCommCredentialExchangeRecord as BaseRecordConstructor<AnyRecord>,
+  [RecordType.DIDCOMM_PROOF]: DidCommProofExchangeRecord as BaseRecordConstructor<AnyRecord>,
+  [RecordType.DIDCOMM_OOB]: DidCommOutOfBandRecord as BaseRecordConstructor<AnyRecord>,
+}
+
+/**
+ * Record types that own `DidCommMessageRecord` children (linked by the `associatedRecordId` tag).
+ *
+ * Only the credential and proof protocols associate stored DIDComm messages with an exchange
+ * record. OOB records carry their invitation inline, and the OID4VC sessions are not DIDComm at
+ * all — so neither needs the extra child query per record.
+ */
+export const RECORD_TYPES_WITH_DIDCOMM_MESSAGE_CHILDREN: ReadonlySet<PurgeRecordType> = new Set([
+  RecordType.DIDCOMM_CREDENTIAL,
+  RecordType.DIDCOMM_PROOF,
+])
+
+export function resolveStorageService(agent: Agent): StorageService<AnyRecord> {
+  return agent.dependencyManager.resolve<StorageService<AnyRecord>>(InjectionSymbols.StorageService)
+}
+
+/** IDs of the `DidCommMessageRecord`s associated with an exchange record. */
+export async function findDidCommMessageChildIds(agent: Agent, parentRecordId: string): Promise<string[]> {
+  const storageService = resolveStorageService(agent)
+  const messages = await storageService.findByQuery(agent.context, DidCommMessageRecord, {
+    associatedRecordId: parentRecordId,
+  })
+  return messages.map((message) => message.id)
+}
+
+/**
+ * Delete the `DidCommMessageRecord` children of an exchange record.
+ *
+ * Callers must run this to completion BEFORE deleting the parent: the storage-level parent delete
+ * no longer cascades, so a parent removed while a child delete is still outstanding leaves an
+ * orphaned message that only a full-wallet orphan sweep can find. The steady-state job deliberately
+ * does not run that sweep (INTEGRATION-PLAN-develop.md §8), so this per-parent cascade is the only
+ * thing keeping orphans from accumulating — and that only holds if the ordering is respected.
+ */
+export async function deleteDidCommMessageChildren(agent: Agent, childIds: string[]): Promise<void> {
+  const storageService = resolveStorageService(agent)
+  for (const childId of childIds) {
+    await storageService.deleteById(agent.context, DidCommMessageRecord, childId)
+  }
+}
+
+/**
+ * Delete a single purgeable record — the parent record ONLY.
+ *
+ * @throws {RecordNotFoundError} if the record is already gone. Callers treat this as an idempotent
+ * success: for a delete, "already absent" is the desired end state.
+ */
 export async function deletePurgeRecord(agent: Agent, recordType: PurgeRecordType, recordId: string): Promise<void> {
+  const recordClass = STORAGE_LEVEL_RECORD_CLASSES[recordType]
+  if (recordClass) {
+    await resolveStorageService(agent).deleteById(agent.context, recordClass, recordId)
+    return
+  }
+
   switch (recordType) {
-    case PurgeRecordType.DIDCOMM_CREDENTIAL:
-      await (agent as any).modules.didcomm.credentials.deleteById(recordId)
-      break
-
-    case PurgeRecordType.DIDCOMM_PROOF:
-      await (agent as any).modules.didcomm.proofs.deleteById(recordId)
-      break
-
-    case PurgeRecordType.OID4VC_ISSUANCE: {
+    // The OID4VC repositories are already parent-only — no protocol cascade to bypass.
+    case RecordType.OID4VC_ISSUANCE: {
       const repo = agent.dependencyManager.resolve(OpenId4VcIssuanceSessionRepository)
       await repo.deleteById(agent.context, recordId)
       break
     }
 
-    case PurgeRecordType.OID4VC_VERIFICATION: {
+    case RecordType.OID4VC_VERIFICATION: {
       const repo = agent.dependencyManager.resolve(OpenId4VcVerificationSessionRepository)
       await repo.deleteById(agent.context, recordId)
       break
     }
 
     default: {
-      const _exhaustive: never = recordType
+      const _exhaustive: never = recordType as never
       throw new Error(`[Purge] Unhandled record type: ${_exhaustive}`)
     }
   }

--- a/src/purge/PurgeDeleteRecord.ts
+++ b/src/purge/PurgeDeleteRecord.ts
@@ -1,7 +1,7 @@
 import type { PurgeRecordType } from './PurgeTypes'
 import type { Agent, BaseRecord, BaseRecordConstructor, StorageService } from '@credo-ts/core'
 
-import { InjectionSymbols } from '@credo-ts/core'
+import { InjectionSymbols, RecordNotFoundError } from '@credo-ts/core'
 import {
   DidCommCredentialExchangeRecord,
   DidCommMessageRecord,
@@ -70,12 +70,28 @@ export async function findDidCommMessageChildIds(agent: Agent, parentRecordId: s
  * orphaned message that only a full-wallet orphan sweep can find. The steady-state job deliberately
  * does not run that sweep (INTEGRATION-PLAN-develop.md §8), so this per-parent cascade is the only
  * thing keeping orphans from accumulating — and that only holds if the ordering is respected.
+ *
+ * A child that is ALREADY gone is skipped rather than treated as an error: for a delete, "absent" is
+ * the desired end state. Letting `RecordNotFoundError` escape here would abort the cascade and, via
+ * the caller's error handling, leave the parent undeleted while reporting the record as successfully
+ * already-absent — so a wallet with a partially-completed previous run could make only partial
+ * progress on every subsequent run while looking healthy.
+ *
+ * @returns the number of children that are no longer present (deleted here or already gone).
  */
-export async function deleteDidCommMessageChildren(agent: Agent, childIds: string[]): Promise<void> {
+export async function deleteDidCommMessageChildren(agent: Agent, childIds: string[]): Promise<number> {
   const storageService = resolveStorageService(agent)
+  let removed = 0
   for (const childId of childIds) {
-    await storageService.deleteById(agent.context, DidCommMessageRecord, childId)
+    try {
+      await storageService.deleteById(agent.context, DidCommMessageRecord, childId)
+    } catch (error) {
+      // Real failures (lock, I/O) still propagate, so the parent is not deleted and is retried.
+      if (!(error instanceof RecordNotFoundError)) throw error
+    }
+    removed++
   }
+  return removed
 }
 
 /**

--- a/src/purge/PurgeEngine.ts
+++ b/src/purge/PurgeEngine.ts
@@ -449,8 +449,7 @@ async function processRecord(
     // the whole record is retried on the next run — the alternative is an orphaned message that
     // only a full-wallet sweep could ever find again.
     if (childIds.length > 0) {
-      await deleteDidCommMessageChildren(ctx.agent, childIds)
-      result.childrenDeleted += childIds.length
+      result.childrenDeleted += await deleteDidCommMessageChildren(ctx.agent, childIds)
     }
 
     await deletePurgeRecord(ctx.agent, recordType, record.id)

--- a/src/purge/PurgeEngine.ts
+++ b/src/purge/PurgeEngine.ts
@@ -37,11 +37,12 @@ import {
   deleteDidCommMessageChildren,
   deletePurgeRecord,
   findDidCommMessageChildIds,
+  findPurgeRecordById,
 } from './PurgeDeleteRecord'
 import {
   DIDCOMM_CREDENTIAL_TERMINAL_STATES,
   DIDCOMM_OOB_PURGEABLE_STATES,
-  DIDCOMM_PROOF_NON_TERMINAL_STATES,
+  DIDCOMM_PROOF_ABANDONABLE_STATES,
   DIDCOMM_PROOF_TERMINAL_STATES,
   OID4VC_ISSUANCE_TERMINAL_STATES,
   OID4VC_VERIFICATION_TERMINAL_STATES,
@@ -51,6 +52,8 @@ import { PurgeRecordType } from './PurgeTypes'
 /** The subset of a Credo record the engine reads. Kept structural so the engine stays testable. */
 export interface PurgeableRecord {
   id: string
+  /** Re-checked immediately before deletion; a record that has moved on is left alone. */
+  state?: string
   createdAt?: Date | string
   updatedAt?: Date | string
   /** Present on `DidCommOutOfBandRecord`; drives the reusable-invitation retention rule. */
@@ -84,6 +87,8 @@ export interface PurgeCategoryResult {
   childrenDeleted: number
   /** Deletes that found the record already gone — an idempotent success, not a failure. */
   alreadyAbsent: number
+  /** Eligible at scan time but no longer eligible at delete time; left alone, not an error. */
+  skippedChanged: number
   failed: number
   /** True when the per-tenant time budget cut this category short; it resumes next run. */
   truncated: boolean
@@ -229,6 +234,7 @@ export async function purgeTenant(
       parentsDeleted: c.parentsDeleted,
       childrenDeleted: c.childrenDeleted,
       alreadyAbsent: c.alreadyAbsent,
+      skippedChanged: c.skippedChanged,
       failed: c.failed,
     })),
   })
@@ -269,7 +275,7 @@ export function buildScanPlans(recordType: PurgeRecordTypeValue, config: PurgeCr
       // re-requests — no credential data is at risk. The equivalent for credentials is unsafe and
       // is not offered at all.
       if (config.staleProofEnabled) {
-        for (const state of DIDCOMM_PROOF_NON_TERMINAL_STATES) {
+        for (const state of DIDCOMM_PROOF_ABANDONABLE_STATES) {
           plans.push({ label: `abandoned state=${state}`, query: { state }, cutoff: abandonedCutoff })
         }
       }
@@ -409,17 +415,20 @@ async function runScanPlan(
     }
     result.eligible += eligible.length
 
-    const before = { parents: result.parentsDeleted, absent: result.alreadyAbsent }
+    const before = { parents: result.parentsDeleted, absent: result.alreadyAbsent, skipped: result.skippedChanged }
     for (const record of eligible) {
-      await processRecord(ctx, recordType, record, result)
+      await processRecord(ctx, recordType, plan, record, result)
     }
+    // A record skipped because it changed under us counts as progress: it is gone from the eligible
+    // set for the right reason, and the offset must advance past it or the drain would stall.
     const removed = result.parentsDeleted - before.parents + (result.alreadyAbsent - before.absent)
+    const settled = removed + (result.skippedChanged - before.skipped)
 
     // Zero-progress guard (credo-data-purge `assertDeleteProgress`): if a page had eligible records
     // and not one of them could be removed, something systemic is wrong — a lock, a poison record, a
     // broken store. Aborting the record type beats grinding through the rest logging the same error.
     // It also prevents an infinite loop: with nothing removed the offset below would not advance.
-    if (!dryRun && eligible.length > 0 && removed === 0) {
+    if (!dryRun && eligible.length > 0 && settled === 0) {
       throw new Error(
         `[Purge] ${recordType} ${plan.label}: 0/${eligible.length} deletes succeeded on this page — ` +
           'possible lock or poison record. Aborting this record type.',
@@ -441,6 +450,7 @@ async function runScanPlan(
       scanned: records.length,
       eligible: eligible.length,
       removed,
+      skippedChanged: result.skippedChanged - before.skipped,
       nextOffset: offset,
       dryRun,
     })
@@ -455,12 +465,42 @@ async function runScanPlan(
 async function processRecord(
   ctx: EngineContext,
   recordType: PurgeRecordTypeValue,
+  plan: ScanPlan,
   record: PurgeableRecord,
   result: PurgeCategoryResult,
 ): Promise<void> {
   const cascade = RECORD_TYPES_WITH_DIDCOMM_MESSAGE_CHILDREN.has(recordType)
 
   try {
+    // Re-read and re-evaluate immediately before deleting. The page was a snapshot, and records are
+    // processed sequentially behind a throttle, so a record can move on while it waits its turn —
+    // a holder can answer a long-abandoned proof request in exactly that window. Deleting on the
+    // stale snapshot would take out a flow that had just become live again. This is also what makes
+    // the claim that the cron path (unlike the NATS one) decides at DELETE time rather than at
+    // schedule time actually true.
+    //
+    // It closes the cascade race too: a concurrent response creates a new DidCommMessageRecord as
+    // part of a state transition on the parent, so a parent that still matches its plan here has not
+    // gained children since the scan.
+    const fresh = await findPurgeRecordById(ctx.agent, recordType, record.id)
+    if (!fresh) {
+      result.alreadyAbsent++
+      ctx.onDeleted?.(recordType, record.id, true)
+      return
+    }
+    if (!stillMatchesPlan(fresh, plan)) {
+      result.skippedChanged++
+      ctx.logger.debug('[Purge] Record changed since the scan — leaving it alone', {
+        runId: ctx.runId,
+        tenantId: ctx.tenantId,
+        recordType,
+        recordId: record.id,
+        plan: plan.label,
+        state: fresh.state,
+      })
+      return
+    }
+
     const childIds = cascade ? await findDidCommMessageChildIds(ctx.agent, record.id) : []
 
     if (ctx.config.dryRun) {
@@ -515,6 +555,17 @@ async function processRecord(
  * A record with neither timestamp is never eligible: without an age there is no way to show it is
  * past TTL, and refusing to delete is the safe default.
  */
+/**
+ * Whether a freshly-read record still satisfies the plan that selected it: same state, still past
+ * the cutoff, and still not retained by policy.
+ */
+function stillMatchesPlan(record: PurgeableRecord, plan: ScanPlan): boolean {
+  const expectedState = plan.query.state
+  if (expectedState !== undefined && record.state !== expectedState) return false
+  if (!isPastCutoff(record, plan.cutoff)) return false
+  return !plan.retain?.(record)
+}
+
 function isPastCutoff(record: PurgeableRecord, cutoff: Date): boolean {
   const timestamp = toDate(record.updatedAt) ?? toDate(record.createdAt)
   if (!timestamp) return false
@@ -546,6 +597,7 @@ function emptyCategoryResult(recordType: PurgeRecordTypeValue): PurgeCategoryRes
     parentsDeleted: 0,
     childrenDeleted: 0,
     alreadyAbsent: 0,
+    skippedChanged: 0,
     failed: 0,
     truncated: false,
   }

--- a/src/purge/PurgeEngine.ts
+++ b/src/purge/PurgeEngine.ts
@@ -25,7 +25,7 @@
  * purged every day, the terminal-state set stays bounded to roughly one TTL window (§8).
  */
 import type { PurgeCronConfig, PurgeRecordType as PurgeRecordTypeValue } from './PurgeTypes'
-import type { Agent, Logger } from '@credo-ts/core'
+import type { Agent, Logger, QueryOptions } from '@credo-ts/core'
 
 import { RecordNotFoundError } from '@credo-ts/core'
 import { OpenId4VcIssuanceSessionRepository, OpenId4VcVerificationSessionRepository } from '@credo-ts/openid4vc'
@@ -123,11 +123,17 @@ interface EngineContext {
   runId: string
   /** Absolute time after which the tenant is abandoned for this run; undefined when unbudgeted. */
   deadline?: number
-  /** Invoked after each successful parent delete — used for the deprecated webhook notification. */
-  onDeleted?: (recordType: PurgeRecordTypeValue, recordId: string, alreadyAbsent: boolean) => Promise<void>
+  /**
+   * Invoked after each parent delete for the deprecated webhook notification. Deliberately
+   * synchronous / fire-and-forget: `sendPurgeWebhook` retries [1s, 5s, 30s] with a 10s per-attempt
+   * timeout, so awaiting it inline would stall the sequential delete loop by up to ~46s PER RECORD
+   * against an endpoint that does not exist — holding the tenant session open for hours. Delivery is
+   * best-effort; the per-run audit log is the authoritative record.
+   */
+  onDeleted?: (recordType: PurgeRecordTypeValue, recordId: string, alreadyAbsent: boolean) => void
 }
 
-type ScanFn = (query: Record<string, unknown>) => Promise<PurgeableRecord[]>
+type ScanFn = (query: Record<string, unknown>, queryOptions: QueryOptions) => Promise<PurgeableRecord[]>
 
 /**
  * Purge one wallet (a tenant agent in shared mode, or the root agent in dedicated mode).
@@ -141,6 +147,12 @@ export async function purgeTenant(
   config: PurgeCronConfig,
   runId: string,
   onDeleted?: EngineContext['onDeleted'],
+  /**
+   * Rotates which record type is processed first. Only meaningful with a time budget: without
+   * rotation a truncated tenant always spends its budget on the same leading types, so the ones at
+   * the back of a fixed order (OOB is third, and the largest category in production) would never run.
+   */
+  rotation = 0,
 ): Promise<PurgeTenantResult> {
   const startedAt = Date.now()
   const ctx: EngineContext = {
@@ -155,7 +167,7 @@ export async function purgeTenant(
 
   const categories: PurgeCategoryResult[] = []
 
-  for (const recordType of config.recordTypes) {
+  for (const recordType of rotate(config.recordTypes, rotation)) {
     const result = emptyCategoryResult(recordType)
     categories.push(result)
 
@@ -167,11 +179,14 @@ export async function purgeTenant(
     } catch (error) {
       if (error instanceof TimeBudgetExceededError) {
         result.truncated = true
-        ctx.logger.warn('[Purge] Time budget exhausted — tenant will resume on the next run', {
+        // Note the budget is PER TENANT (the deadline is computed from this tenant's own start), so
+        // truncating here does not eat into any later tenant's allowance.
+        ctx.logger.warn('[Purge] Time budget exhausted — remaining work continues on subsequent runs', {
           runId,
           tenantId,
-          recordType,
+          stoppedAt: recordType,
           timeBudgetMs: config.timeBudgetMs,
+          note: 'record-type order rotates each run so no type is starved',
         })
         break
       }
@@ -315,24 +330,24 @@ function buildScanFn(agent: Agent, recordType: PurgeRecordTypeValue): ScanFn {
   switch (recordType) {
     case PurgeRecordType.DIDCOMM_CREDENTIAL:
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return (query) => (agent as any).modules.didcomm.credentials.findAllByQuery(query)
+      return (query, queryOptions) => (agent as any).modules.didcomm.credentials.findAllByQuery(query, queryOptions)
 
     case PurgeRecordType.DIDCOMM_PROOF:
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return (query) => (agent as any).modules.didcomm.proofs.findAllByQuery(query)
+      return (query, queryOptions) => (agent as any).modules.didcomm.proofs.findAllByQuery(query, queryOptions)
 
     case PurgeRecordType.DIDCOMM_OOB:
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return (query) => (agent as any).modules.didcomm.oob.findAllByQuery(query)
+      return (query, queryOptions) => (agent as any).modules.didcomm.oob.findAllByQuery(query, queryOptions)
 
     case PurgeRecordType.OID4VC_ISSUANCE: {
       const repo = agent.dependencyManager.resolve(OpenId4VcIssuanceSessionRepository)
-      return (query) => repo.findByQuery(agent.context, query)
+      return (query, queryOptions) => repo.findByQuery(agent.context, query, queryOptions)
     }
 
     case PurgeRecordType.OID4VC_VERIFICATION: {
       const repo = agent.dependencyManager.resolve(OpenId4VcVerificationSessionRepository)
-      return (query) => repo.findByQuery(agent.context, query)
+      return (query, queryOptions) => repo.findByQuery(agent.context, query, queryOptions)
     }
 
     default: {
@@ -349,79 +364,89 @@ async function runScanPlan(
   scan: ScanFn,
   result: PurgeCategoryResult,
 ): Promise<void> {
+  const { batchSize, throttleMs, dryRun } = ctx.config
+
+  // Drain the plan one bounded page at a time. The earlier revision fetched the whole state-scoped
+  // result set in a single call, which is only survivable once the wallet is already drained: on an
+  // undrained wallet `state=request-sent` alone was the clear majority of all proof exchanges,
+  // and materialising them decrypted into the live agent's heap means an OOM or GC pauses that hit
+  // credential and proof traffic. Nothing forces the backfill to run first, so the scan itself has
+  // to be bounded rather than relying on the steady state described in §8.
+  //
+  // Askar gives no stable sort across separate scan calls, so paging can skip or re-see a record.
+  // For a DELETE workload both are benign and self-correcting: a skipped record is picked up by the
+  // next run, and a re-seen one is already gone and counts as an idempotent already-absent. (This is
+  // exactly why credo-data-purge forbids paging in its ORPHAN SWEEP but uses offset-reset loops in
+  // bulk-purge — completeness is load-bearing there, not here.)
+  // Gate on entry, before paying for this plan's first scan. Without this a plan is only checked
+  // between its own pages, so a category made of many single-page plans would run all of them no
+  // matter how far past the budget it already was.
   assertWithinTimeBudget(ctx)
 
-  // One continuous scan per plan, with no {limit, offset} paging. Askar applies no stable sort
-  // across separate scan calls, so paginating a category over multiple queries silently skips or
-  // double-counts rows — a hazard measured and documented in credo-data-purge's purgeOrphans. The
-  // `state` tag keeps the result set bounded to roughly one TTL window in steady state (§8); the
-  // *deletes* are what get batched and throttled below.
-  const records = await scan(plan.query)
-  result.scanned += records.length
+  let offset = 0
+  let page = 0
 
-  const eligible: PurgeableRecord[] = []
-  for (const record of records) {
-    if (!isPastCutoff(record, plan.cutoff)) continue
-    if (plan.retain?.(record)) {
-      result.retainedByPolicy++
-      continue
+  for (;;) {
+    // Within a plan the first page is never budget-gated, so a plan that has already paid for a scan
+    // always makes some forward progress; otherwise a tenant whose scan alone outlasts the budget
+    // would pay for the scan and delete nothing on every run, forever. Overshoot is one page.
+    if (page > 0) assertWithinTimeBudget(ctx)
+
+    const records = await scan(plan.query, { limit: batchSize, offset })
+    if (records.length === 0) break
+
+    page++
+    result.scanned += records.length
+
+    const eligible: PurgeableRecord[] = []
+    for (const record of records) {
+      if (!isPastCutoff(record, plan.cutoff)) continue
+      if (plan.retain?.(record)) {
+        result.retainedByPolicy++
+        continue
+      }
+      eligible.push(record)
     }
-    eligible.push(record)
-  }
-  result.eligible += eligible.length
+    result.eligible += eligible.length
 
-  ctx.logger.debug('[Purge] Scan plan complete', {
-    runId: ctx.runId,
-    tenantId: ctx.tenantId,
-    recordType,
-    plan: plan.label,
-    scanned: records.length,
-    eligible: eligible.length,
-  })
-
-  if (eligible.length === 0) return
-
-  const { batchSize, throttleMs } = ctx.config
-
-  for (let offset = 0; offset < eligible.length; offset += batchSize) {
-    // The first batch of a plan is never budget-gated. The scan has already been paid for by this
-    // point, so bailing out before deleting anything would burn the expensive half of the work and
-    // make no progress — and a tenant whose scan alone outlasts the budget would then never purge
-    // anything, on any run. Letting one batch through guarantees forward progress; the overshoot is
-    // bounded by batchSize.
-    if (offset > 0) assertWithinTimeBudget(ctx)
-
-    const batch = eligible.slice(offset, offset + batchSize)
-    const before = { parents: result.parentsDeleted, absent: result.alreadyAbsent, failed: result.failed }
-
-    for (const record of batch) {
+    const before = { parents: result.parentsDeleted, absent: result.alreadyAbsent }
+    for (const record of eligible) {
       await processRecord(ctx, recordType, record, result)
     }
+    const removed = result.parentsDeleted - before.parents + (result.alreadyAbsent - before.absent)
 
-    const progressed =
-      result.parentsDeleted - before.parents > 0 ||
-      result.alreadyAbsent - before.absent > 0 ||
-      // In dry-run nothing is deleted, so "no progress" is the expected outcome, not a failure.
-      ctx.config.dryRun
-
-    // Zero-progress guard (credo-data-purge `assertDeleteProgress`): if every delete in a batch
-    // genuinely failed, something systemic is wrong — a lock, a poison record, a broken store.
-    // Aborting the category beats grinding through the whole eligible set logging the same error.
-    if (!progressed) {
+    // Zero-progress guard (credo-data-purge `assertDeleteProgress`): if a page had eligible records
+    // and not one of them could be removed, something systemic is wrong — a lock, a poison record, a
+    // broken store. Aborting the record type beats grinding through the rest logging the same error.
+    // It also prevents an infinite loop: with nothing removed the offset below would not advance.
+    if (!dryRun && eligible.length > 0 && removed === 0) {
       throw new Error(
-        `[Purge] ${recordType} ${plan.label}: 0/${batch.length} deletes succeeded in this batch — ` +
+        `[Purge] ${recordType} ${plan.label}: 0/${eligible.length} deletes succeeded on this page — ` +
           'possible lock or poison record. Aborting this record type.',
       )
     }
 
-    ctx.logger.debug('[Purge] Batch complete', {
+    // Advance past only the records left behind (too recent, retained by policy, or failed).
+    // Removed records are gone from the result set, so the next page starts where they were. In
+    // dry-run nothing is removed, so the offset must advance by the full page or it would re-read
+    // the same page forever.
+    offset += dryRun ? records.length : records.length - removed
+
+    ctx.logger.debug('[Purge] Page complete', {
       runId: ctx.runId,
       tenantId: ctx.tenantId,
       recordType,
       plan: plan.label,
-      progress: `${Math.min(offset + batch.length, eligible.length)}/${eligible.length}`,
-      dryRun: ctx.config.dryRun,
+      page,
+      scanned: records.length,
+      eligible: eligible.length,
+      removed,
+      nextOffset: offset,
+      dryRun,
     })
+
+    // A short page means the query is exhausted.
+    if (records.length < batchSize) break
 
     if (throttleMs > 0) await sleep(throttleMs)
   }
@@ -454,7 +479,7 @@ async function processRecord(
 
     await deletePurgeRecord(ctx.agent, recordType, record.id)
     result.parentsDeleted++
-    await ctx.onDeleted?.(recordType, record.id, false)
+    ctx.onDeleted?.(recordType, record.id, false)
   } catch (error) {
     if (error instanceof RecordNotFoundError) {
       // Idempotent success: the desired end state (record gone) already holds. Happens on retries
@@ -466,7 +491,7 @@ async function processRecord(
         recordType,
         recordId: record.id,
       })
-      await ctx.onDeleted?.(recordType, record.id, true)
+      ctx.onDeleted?.(recordType, record.id, true)
       return
     }
 
@@ -524,6 +549,13 @@ function emptyCategoryResult(recordType: PurgeRecordTypeValue): PurgeCategoryRes
     failed: 0,
     truncated: false,
   }
+}
+
+/** Left-rotate so a different record type leads each run. */
+function rotate<T>(items: T[], by: number): T[] {
+  if (items.length === 0) return items
+  const shift = ((by % items.length) + items.length) % items.length
+  return shift === 0 ? items : [...items.slice(shift), ...items.slice(0, shift)]
 }
 
 function sumBy<T>(items: T[], pick: (item: T) => number): number {

--- a/src/purge/PurgeEngine.ts
+++ b/src/purge/PurgeEngine.ts
@@ -1,0 +1,504 @@
+/**
+ * State-aware, batched, throttled purge engine — the steady-state ("Tier B") purge that runs inside
+ * the live agent process.
+ *
+ * The algorithm is ported from the validated operator batch tool `credo-data-purge`
+ * (`src/purge-core.ts`), which stays the source of truth for purge semantics
+ * (INTEGRATION-PLAN-develop.md §4.2, §4.3, §6). Three deliberate divergences from the batch tool,
+ * each because this code shares a process and a DB pool with the live agent:
+ *
+ *  1. **No global orphan sweep.** The batch tool's set-based sweep is O(total records) on every run
+ *     and must not sit in a daily in-process job (§8). Instead each eligible parent's
+ *     `DidCommMessageRecord` children are cascaded per-parent, so cost scales with the (small) daily
+ *     delta and no new orphans are created. Legacy orphans left behind by past bulk deletes are a
+ *     one-off `credo-data-purge` job, not this one's problem.
+ *  2. **Sequential deletes within a batch** instead of `Promise.allSettled` over all 100. The batch
+ *     tool runs standalone in a maintenance window and can afford 100 concurrent Askar sessions;
+ *     here that many concurrent sessions would compete with live request traffic for the same pool.
+ *     Throughput is not the constraint — a steady-state run has a small delta by construction.
+ *  3. **Children are deleted before the parent, and the parent is skipped if any child delete
+ *     fails.** The batch tool submits both in one settled batch and relies on its orphan sweep as
+ *     the backstop; without that backstop the ordering has to be strict (see §8 reasoning above).
+ *
+ * Scanning is state-scoped (`findByQuery({ state })`, an indexed tag) rather than
+ * `findAllByQuery({})`, which is what makes a daily run cheap: once terminal records past TTL are
+ * purged every day, the terminal-state set stays bounded to roughly one TTL window (§8).
+ */
+import type { PurgeCronConfig, PurgeRecordType as PurgeRecordTypeValue } from './PurgeTypes'
+import type { Agent, Logger } from '@credo-ts/core'
+
+import { RecordNotFoundError } from '@credo-ts/core'
+import { OpenId4VcIssuanceSessionRepository, OpenId4VcVerificationSessionRepository } from '@credo-ts/openid4vc'
+
+import { sleep } from '../utils/webhook'
+
+import {
+  RECORD_TYPES_WITH_DIDCOMM_MESSAGE_CHILDREN,
+  deleteDidCommMessageChildren,
+  deletePurgeRecord,
+  findDidCommMessageChildIds,
+} from './PurgeDeleteRecord'
+import {
+  DIDCOMM_CREDENTIAL_TERMINAL_STATES,
+  DIDCOMM_OOB_PURGEABLE_STATES,
+  DIDCOMM_PROOF_NON_TERMINAL_STATES,
+  DIDCOMM_PROOF_TERMINAL_STATES,
+  OID4VC_ISSUANCE_TERMINAL_STATES,
+  OID4VC_VERIFICATION_TERMINAL_STATES,
+} from './PurgeStates'
+import { PurgeRecordType } from './PurgeTypes'
+
+/** The subset of a Credo record the engine reads. Kept structural so the engine stays testable. */
+export interface PurgeableRecord {
+  id: string
+  createdAt?: Date | string
+  updatedAt?: Date | string
+  /** Present on `DidCommOutOfBandRecord`; drives the reusable-invitation retention rule. */
+  reusable?: boolean
+}
+
+export interface PurgeCategoryResult {
+  recordType: PurgeRecordTypeValue
+  /** Records returned by the state-scoped scans. */
+  scanned: number
+  /** Past TTL and not retained by policy. */
+  eligible: number
+  /** Past TTL but deliberately kept (currently only reusable `await-response` OOB invitations). */
+  retainedByPolicy: number
+  parentsDeleted: number
+  childrenDeleted: number
+  /** Deletes that found the record already gone — an idempotent success, not a failure. */
+  alreadyAbsent: number
+  failed: number
+  /** True when the per-tenant time budget cut this category short; it resumes next run. */
+  truncated: boolean
+}
+
+export interface PurgeTenantResult {
+  tenantId: string
+  dryRun: boolean
+  durationMs: number
+  categories: PurgeCategoryResult[]
+  eligible: number
+  parentsDeleted: number
+  childrenDeleted: number
+  failed: number
+  truncated: boolean
+}
+
+/** Thrown internally when the per-tenant wall-clock budget is exhausted. Never escapes `purgeTenant`. */
+class TimeBudgetExceededError extends Error {}
+
+interface ScanPlan {
+  /** Human-readable plan name for the audit log, e.g. `state=done`. */
+  label: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  query: Record<string, any>
+  /** Records with `updatedAt` at or before this instant are past TTL. */
+  cutoff: Date
+  /** Returns true when a past-TTL record must nonetheless be kept. */
+  retain?: (record: PurgeableRecord) => boolean
+}
+
+interface EngineContext {
+  agent: Agent
+  tenantId: string
+  config: PurgeCronConfig
+  logger: Logger
+  runId: string
+  /** Absolute time after which the tenant is abandoned for this run; undefined when unbudgeted. */
+  deadline?: number
+  /** Invoked after each successful parent delete — used for the deprecated webhook notification. */
+  onDeleted?: (recordType: PurgeRecordTypeValue, recordId: string, alreadyAbsent: boolean) => Promise<void>
+}
+
+type ScanFn = (query: Record<string, unknown>) => Promise<PurgeableRecord[]>
+
+/**
+ * Purge one wallet (a tenant agent in shared mode, or the root agent in dedicated mode).
+ *
+ * Never throws for per-category failures: each record type is isolated so a poison record in one
+ * category cannot stop the others. The caller isolates tenants from each other in the same way.
+ */
+export async function purgeTenant(
+  agent: Agent,
+  tenantId: string,
+  config: PurgeCronConfig,
+  runId: string,
+  onDeleted?: EngineContext['onDeleted'],
+): Promise<PurgeTenantResult> {
+  const startedAt = Date.now()
+  const ctx: EngineContext = {
+    agent,
+    tenantId,
+    config,
+    logger: agent.config.logger,
+    runId,
+    deadline: config.timeBudgetMs > 0 ? startedAt + config.timeBudgetMs : undefined,
+    onDeleted,
+  }
+
+  const categories: PurgeCategoryResult[] = []
+
+  for (const recordType of config.recordTypes) {
+    const result = emptyCategoryResult(recordType)
+    categories.push(result)
+
+    try {
+      const scan = buildScanFn(agent, recordType)
+      for (const plan of buildScanPlans(recordType, config)) {
+        await runScanPlan(ctx, recordType, plan, scan, result)
+      }
+    } catch (error) {
+      if (error instanceof TimeBudgetExceededError) {
+        result.truncated = true
+        ctx.logger.warn('[Purge] Time budget exhausted — tenant will resume on the next run', {
+          runId,
+          tenantId,
+          recordType,
+          timeBudgetMs: config.timeBudgetMs,
+        })
+        break
+      }
+      ctx.logger.error('[Purge] Record type failed — continuing with the next type', {
+        runId,
+        tenantId,
+        recordType,
+        error: (error as Error)?.message,
+      })
+    }
+  }
+
+  const summary: PurgeTenantResult = {
+    tenantId,
+    dryRun: config.dryRun,
+    durationMs: Date.now() - startedAt,
+    categories,
+    eligible: sumBy(categories, (c) => c.eligible),
+    parentsDeleted: sumBy(categories, (c) => c.parentsDeleted),
+    childrenDeleted: sumBy(categories, (c) => c.childrenDeleted),
+    failed: sumBy(categories, (c) => c.failed),
+    truncated: categories.some((c) => c.truncated),
+  }
+
+  ctx.logger.info('[Purge] Tenant summary', {
+    runId,
+    tenantId: tenantId || '(dedicated)',
+    dryRun: summary.dryRun,
+    durationMs: summary.durationMs,
+    eligible: summary.eligible,
+    parentsDeleted: summary.parentsDeleted,
+    childrenDeleted: summary.childrenDeleted,
+    failed: summary.failed,
+    truncated: summary.truncated,
+    byType: categories.map((c) => ({
+      recordType: c.recordType,
+      scanned: c.scanned,
+      eligible: c.eligible,
+      retainedByPolicy: c.retainedByPolicy,
+      parentsDeleted: c.parentsDeleted,
+      childrenDeleted: c.childrenDeleted,
+      alreadyAbsent: c.alreadyAbsent,
+      failed: c.failed,
+    })),
+  })
+
+  return summary
+}
+
+/**
+ * The retention policy, expressed as the set of queries the purge is allowed to run.
+ *
+ * Safety is structural rather than checked: because credentials only ever get plans built from
+ * `DIDCOMM_CREDENTIAL_TERMINAL_STATES`, there is no configuration or code path that can make the
+ * engine query a non-terminal credential state. See `PurgeStates.ts` for why that matters.
+ */
+export function buildScanPlans(recordType: PurgeRecordTypeValue, config: PurgeCronConfig): ScanPlan[] {
+  const cutoff = cutoffFor(config.ttlSeconds)
+
+  switch (recordType) {
+    case PurgeRecordType.DIDCOMM_CREDENTIAL:
+      return DIDCOMM_CREDENTIAL_TERMINAL_STATES.map((state) => ({
+        label: `state=${state}`,
+        query: { state },
+        cutoff,
+      }))
+
+    case PurgeRecordType.DIDCOMM_PROOF: {
+      const plans: ScanPlan[] = DIDCOMM_PROOF_TERMINAL_STATES.map((state) => ({
+        label: `state=${state}`,
+        query: { state },
+        cutoff,
+      }))
+
+      // Opt-in only, and against its own far longer TTL, so an in-flight verification is never
+      // caught. A holder answering a deleted proof request just gets an error and the verifier
+      // re-requests — no credential data is at risk. The equivalent for credentials is unsafe and
+      // is not offered at all.
+      if (config.staleProofEnabled) {
+        const staleCutoff = cutoffFor(config.staleProofTtlSeconds)
+        for (const state of DIDCOMM_PROOF_NON_TERMINAL_STATES) {
+          plans.push({ label: `stale state=${state}`, query: { state }, cutoff: staleCutoff })
+        }
+      }
+
+      return plans
+    }
+
+    case PurgeRecordType.DIDCOMM_OOB:
+      return [
+        {
+          label: `state=${DIDCOMM_OOB_PURGEABLE_STATES.terminal}`,
+          query: { state: DIDCOMM_OOB_PURGEABLE_STATES.terminal },
+          cutoff,
+        },
+        {
+          label: `state=${DIDCOMM_OOB_PURGEABLE_STATES.stuck} (non-reusable only)`,
+          query: { state: DIDCOMM_OOB_PURGEABLE_STATES.stuck },
+          cutoff,
+          // A reusable await-response record backs a published invitation URL / QR code. Deleting it
+          // breaks every future scan, so it is retained regardless of age.
+          retain: (record) => record.reusable === true,
+        },
+      ]
+
+    case PurgeRecordType.OID4VC_ISSUANCE:
+      return OID4VC_ISSUANCE_TERMINAL_STATES.map((state) => ({
+        label: `state=${state}`,
+        query: { state },
+        cutoff,
+      }))
+
+    case PurgeRecordType.OID4VC_VERIFICATION:
+      return OID4VC_VERIFICATION_TERMINAL_STATES.map((state) => ({
+        label: `state=${state}`,
+        query: { state },
+        cutoff,
+      }))
+
+    default: {
+      const _exhaustive: never = recordType as never
+      throw new Error(`[Purge] No scan plan for record type: ${_exhaustive}`)
+    }
+  }
+}
+
+function buildScanFn(agent: Agent, recordType: PurgeRecordTypeValue): ScanFn {
+  switch (recordType) {
+    case PurgeRecordType.DIDCOMM_CREDENTIAL:
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (query) => (agent as any).modules.didcomm.credentials.findAllByQuery(query)
+
+    case PurgeRecordType.DIDCOMM_PROOF:
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (query) => (agent as any).modules.didcomm.proofs.findAllByQuery(query)
+
+    case PurgeRecordType.DIDCOMM_OOB:
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (query) => (agent as any).modules.didcomm.oob.findAllByQuery(query)
+
+    case PurgeRecordType.OID4VC_ISSUANCE: {
+      const repo = agent.dependencyManager.resolve(OpenId4VcIssuanceSessionRepository)
+      return (query) => repo.findByQuery(agent.context, query)
+    }
+
+    case PurgeRecordType.OID4VC_VERIFICATION: {
+      const repo = agent.dependencyManager.resolve(OpenId4VcVerificationSessionRepository)
+      return (query) => repo.findByQuery(agent.context, query)
+    }
+
+    default: {
+      const _exhaustive: never = recordType as never
+      throw new Error(`[Purge] No scan function for record type: ${_exhaustive}`)
+    }
+  }
+}
+
+async function runScanPlan(
+  ctx: EngineContext,
+  recordType: PurgeRecordTypeValue,
+  plan: ScanPlan,
+  scan: ScanFn,
+  result: PurgeCategoryResult,
+): Promise<void> {
+  assertWithinTimeBudget(ctx)
+
+  // One continuous scan per plan, with no {limit, offset} paging. Askar applies no stable sort
+  // across separate scan calls, so paginating a category over multiple queries silently skips or
+  // double-counts rows — a hazard measured and documented in credo-data-purge's purgeOrphans. The
+  // `state` tag keeps the result set bounded to roughly one TTL window in steady state (§8); the
+  // *deletes* are what get batched and throttled below.
+  const records = await scan(plan.query)
+  result.scanned += records.length
+
+  const eligible: PurgeableRecord[] = []
+  for (const record of records) {
+    if (!isPastCutoff(record, plan.cutoff)) continue
+    if (plan.retain?.(record)) {
+      result.retainedByPolicy++
+      continue
+    }
+    eligible.push(record)
+  }
+  result.eligible += eligible.length
+
+  ctx.logger.debug('[Purge] Scan plan complete', {
+    runId: ctx.runId,
+    tenantId: ctx.tenantId,
+    recordType,
+    plan: plan.label,
+    scanned: records.length,
+    eligible: eligible.length,
+  })
+
+  if (eligible.length === 0) return
+
+  const { batchSize, throttleMs } = ctx.config
+
+  for (let offset = 0; offset < eligible.length; offset += batchSize) {
+    // The first batch of a plan is never budget-gated. The scan has already been paid for by this
+    // point, so bailing out before deleting anything would burn the expensive half of the work and
+    // make no progress — and a tenant whose scan alone outlasts the budget would then never purge
+    // anything, on any run. Letting one batch through guarantees forward progress; the overshoot is
+    // bounded by batchSize.
+    if (offset > 0) assertWithinTimeBudget(ctx)
+
+    const batch = eligible.slice(offset, offset + batchSize)
+    const before = { parents: result.parentsDeleted, absent: result.alreadyAbsent, failed: result.failed }
+
+    for (const record of batch) {
+      await processRecord(ctx, recordType, record, result)
+    }
+
+    const progressed =
+      result.parentsDeleted - before.parents > 0 ||
+      result.alreadyAbsent - before.absent > 0 ||
+      // In dry-run nothing is deleted, so "no progress" is the expected outcome, not a failure.
+      ctx.config.dryRun
+
+    // Zero-progress guard (credo-data-purge `assertDeleteProgress`): if every delete in a batch
+    // genuinely failed, something systemic is wrong — a lock, a poison record, a broken store.
+    // Aborting the category beats grinding through the whole eligible set logging the same error.
+    if (!progressed) {
+      throw new Error(
+        `[Purge] ${recordType} ${plan.label}: 0/${batch.length} deletes succeeded in this batch — ` +
+          'possible lock or poison record. Aborting this record type.',
+      )
+    }
+
+    ctx.logger.debug('[Purge] Batch complete', {
+      runId: ctx.runId,
+      tenantId: ctx.tenantId,
+      recordType,
+      plan: plan.label,
+      progress: `${Math.min(offset + batch.length, eligible.length)}/${eligible.length}`,
+      dryRun: ctx.config.dryRun,
+    })
+
+    if (throttleMs > 0) await sleep(throttleMs)
+  }
+}
+
+async function processRecord(
+  ctx: EngineContext,
+  recordType: PurgeRecordTypeValue,
+  record: PurgeableRecord,
+  result: PurgeCategoryResult,
+): Promise<void> {
+  const cascade = RECORD_TYPES_WITH_DIDCOMM_MESSAGE_CHILDREN.has(recordType)
+
+  try {
+    const childIds = cascade ? await findDidCommMessageChildIds(ctx.agent, record.id) : []
+
+    if (ctx.config.dryRun) {
+      // Count what *would* go, so a dry-run census is directly comparable to a live run.
+      result.childrenDeleted += childIds.length
+      result.parentsDeleted++
+      return
+    }
+
+    // Children first, then the parent. If a child delete throws, the parent is left in place and
+    // the whole record is retried on the next run — the alternative is an orphaned message that
+    // only a full-wallet sweep could ever find again.
+    if (childIds.length > 0) {
+      await deleteDidCommMessageChildren(ctx.agent, childIds)
+      result.childrenDeleted += childIds.length
+    }
+
+    await deletePurgeRecord(ctx.agent, recordType, record.id)
+    result.parentsDeleted++
+    await ctx.onDeleted?.(recordType, record.id, false)
+  } catch (error) {
+    if (error instanceof RecordNotFoundError) {
+      // Idempotent success: the desired end state (record gone) already holds. Happens on retries
+      // and when the live agent deleted the record between the scan and the delete.
+      result.alreadyAbsent++
+      ctx.logger.debug('[Purge] Record already absent — treated as deleted', {
+        runId: ctx.runId,
+        tenantId: ctx.tenantId,
+        recordType,
+        recordId: record.id,
+      })
+      await ctx.onDeleted?.(recordType, record.id, true)
+      return
+    }
+
+    result.failed++
+    ctx.logger.error('[Purge] Failed to delete record', {
+      runId: ctx.runId,
+      tenantId: ctx.tenantId,
+      recordType,
+      recordId: record.id,
+      error: (error as Error)?.message,
+    })
+  }
+}
+
+/**
+ * TTL is keyed on `updatedAt` (last activity), not `createdAt`. `AskarStorageService` stamps
+ * `updatedAt` on every save and update, so for a terminal record it is the moment the flow closed —
+ * which is what a retention window should measure. `createdAt` would delete a long-running exchange
+ * that only just completed.
+ *
+ * A record with neither timestamp is never eligible: without an age there is no way to show it is
+ * past TTL, and refusing to delete is the safe default.
+ */
+function isPastCutoff(record: PurgeableRecord, cutoff: Date): boolean {
+  const timestamp = toDate(record.updatedAt) ?? toDate(record.createdAt)
+  if (!timestamp) return false
+  return timestamp.getTime() <= cutoff.getTime()
+}
+
+function toDate(value: Date | string | undefined): Date | undefined {
+  if (value === undefined || value === null) return undefined
+  const date = value instanceof Date ? value : new Date(value)
+  return Number.isNaN(date.getTime()) ? undefined : date
+}
+
+function cutoffFor(ttlSeconds: number): Date {
+  return new Date(Date.now() - ttlSeconds * 1000)
+}
+
+function assertWithinTimeBudget(ctx: EngineContext): void {
+  if (ctx.deadline !== undefined && Date.now() >= ctx.deadline) {
+    throw new TimeBudgetExceededError()
+  }
+}
+
+function emptyCategoryResult(recordType: PurgeRecordTypeValue): PurgeCategoryResult {
+  return {
+    recordType,
+    scanned: 0,
+    eligible: 0,
+    retainedByPolicy: 0,
+    parentsDeleted: 0,
+    childrenDeleted: 0,
+    alreadyAbsent: 0,
+    failed: 0,
+    truncated: false,
+  }
+}
+
+function sumBy<T>(items: T[], pick: (item: T) => number): number {
+  return items.reduce((total, item) => total + pick(item), 0)
+}

--- a/src/purge/PurgeEngine.ts
+++ b/src/purge/PurgeEngine.ts
@@ -55,6 +55,21 @@ export interface PurgeableRecord {
   updatedAt?: Date | string
   /** Present on `DidCommOutOfBandRecord`; drives the reusable-invitation retention rule. */
   reusable?: boolean
+  /** Present on `OpenId4VcIssuanceSessionRecord`; drives the revocation-handle retention rule. */
+  issuanceMetadata?: { StatusListInfo?: unknown } | null
+}
+
+/**
+ * True when an OID4VC issuance session carries the status-list entry needed to revoke the credential
+ * it issued. Written defensively — `issuanceMetadata` is free-form JSON on the record, so a
+ * malformed or unexpected shape must read as "might be revocable" and keep the record rather than
+ * fall through to deletion.
+ */
+function hasStatusListInfo(record: PurgeableRecord): boolean {
+  const info = record.issuanceMetadata?.StatusListInfo
+  if (info === undefined || info === null) return false
+  if (Array.isArray(info)) return info.length > 0
+  return true
 }
 
 export interface PurgeCategoryResult {
@@ -214,7 +229,10 @@ export async function purgeTenant(
  * engine query a non-terminal credential state. See `PurgeStates.ts` for why that matters.
  */
 export function buildScanPlans(recordType: PurgeRecordTypeValue, config: PurgeCronConfig): ScanPlan[] {
+  /** Completed flows — an audit record of something that happened. */
   const cutoff = cutoffFor(config.ttlSeconds)
+  /** Dead flows — nobody responded and nobody will. Shorter by design. */
+  const abandonedCutoff = cutoffFor(config.abandonedTtlSeconds)
 
   switch (recordType) {
     case PurgeRecordType.DIDCOMM_CREDENTIAL:
@@ -236,9 +254,8 @@ export function buildScanPlans(recordType: PurgeRecordTypeValue, config: PurgeCr
       // re-requests — no credential data is at risk. The equivalent for credentials is unsafe and
       // is not offered at all.
       if (config.staleProofEnabled) {
-        const staleCutoff = cutoffFor(config.staleProofTtlSeconds)
         for (const state of DIDCOMM_PROOF_NON_TERMINAL_STATES) {
-          plans.push({ label: `stale state=${state}`, query: { state }, cutoff: staleCutoff })
+          plans.push({ label: `abandoned state=${state}`, query: { state }, cutoff: abandonedCutoff })
         }
       }
 
@@ -253,9 +270,14 @@ export function buildScanPlans(recordType: PurgeRecordTypeValue, config: PurgeCr
           cutoff,
         },
         {
-          label: `state=${DIDCOMM_OOB_PURGEABLE_STATES.stuck} (non-reusable only)`,
+          label: `abandoned state=${DIDCOMM_OOB_PURGEABLE_STATES.stuck} (non-reusable only)`,
           query: { state: DIDCOMM_OOB_PURGEABLE_STATES.stuck },
-          cutoff,
+          // An unscanned invitation is dead in exactly the way an unanswered proof request is, so it
+          // gets the abandoned TTL rather than the terminal one. This matters more than the naming
+          // suggests: OOB was the largest purgeable category in the July 2026 production drain
+          // (~91% of it eligible), and `create-request-oob` mints one of these
+          // per connectionless proof request — so they are the other half of the `request-sent` pile.
+          cutoff: abandonedCutoff,
           // A reusable await-response record backs a published invitation URL / QR code. Deleting it
           // breaks every future scan, so it is retained regardless of age.
           retain: (record) => record.reusable === true,
@@ -267,6 +289,12 @@ export function buildScanPlans(recordType: PurgeRecordTypeValue, config: PurgeCr
         label: `state=${state}`,
         query: { state },
         cutoff,
+        // The issuance session IS the revocation handle: `revokeBySessionId` reads
+        // `issuanceMetadata.StatusListInfo` off this record to get {listId, index, issuerDid}, and
+        // there is no other copy. Purging a revocable session would silently make that credential
+        // permanently unrevocable, so any session carrying status-list info is kept indefinitely.
+        // Sessions without it (nothing to revoke) and `Error` sessions still age out normally.
+        retain: (record) => hasStatusListInfo(record),
       }))
 
     case PurgeRecordType.OID4VC_VERIFICATION:

--- a/src/purge/PurgeStates.ts
+++ b/src/purge/PurgeStates.ts
@@ -1,0 +1,111 @@
+/**
+ * Single source of truth for which record states the purge is allowed to touch.
+ *
+ * Ported from the validated `credo-data-purge` batch tool (`src/states.ts`), which remains the
+ * source of truth for purge semantics — see INTEGRATION-PLAN-develop.md §4.2 / §6. Keep the two
+ * in sync by convention; a shared package is only worth extracting once both repos sit on the
+ * same Credo minor.
+ *
+ * Every state here is written as a Credo enum member rather than a string literal, so a Credo
+ * upgrade that renames or removes a state fails the build instead of silently producing a list
+ * that matches nothing (which would make the purge a no-op) or, worse, matches the wrong thing.
+ * The non-terminal lists are *derived* by exclusion, so a Credo upgrade that adds a new state
+ * automatically classifies it as non-terminal — i.e. fails safe (never purged by the default path).
+ */
+import { DidCommCredentialState, DidCommOutOfBandState, DidCommProofState } from '@credo-ts/didcomm'
+import { OpenId4VcIssuanceSessionState, OpenId4VcVerificationSessionState } from '@credo-ts/openid4vc'
+
+/**
+ * Terminal DIDComm exchange states — a completed/closed flow. Only these are purged by TTL.
+ * Identical for credentials and proofs in Credo 0.6.x, but kept as two lists so a future
+ * divergence in either enum is a compile error rather than a silent mismatch.
+ */
+export const DIDCOMM_CREDENTIAL_TERMINAL_STATES: string[] = [
+  DidCommCredentialState.Done,
+  DidCommCredentialState.Abandoned,
+  DidCommCredentialState.Declined,
+]
+
+export const DIDCOMM_PROOF_TERMINAL_STATES: string[] = [
+  DidCommProofState.Done,
+  DidCommProofState.Abandoned,
+  DidCommProofState.Declined,
+]
+
+/**
+ * Non-terminal credential states. Exported for the safety guard and its regression test ONLY —
+ * the purge path must never query these.
+ *
+ * Credential stale-incomplete purge is intentionally impossible, not merely disabled: a holder can
+ * still be sitting on a pending offer (`offer-received`) in their wallet and accept it after any
+ * TTL. Deleting the issuer-side exchange record while the holder's record lives breaks issuance
+ * with no recovery path other than a brand-new offer — unacceptable for a national identity
+ * credential.
+ */
+export const DIDCOMM_CREDENTIAL_NON_TERMINAL_STATES: string[] = Object.values(DidCommCredentialState).filter(
+  (state) => !DIDCOMM_CREDENTIAL_TERMINAL_STATES.includes(state),
+)
+
+/**
+ * Non-terminal proof states — purged only under the opt-in stale-proof policy, against a
+ * separate and more conservative TTL (see `PURGE_CRON_STALE_PROOF_TTL_SECONDS`).
+ *
+ * Stale proof exchanges are safe to purge where stale credentials are not: a holder that responds
+ * to a deleted proof request gets an error and the verifier simply re-requests. No credential data
+ * is at risk.
+ */
+export const DIDCOMM_PROOF_NON_TERMINAL_STATES: string[] = Object.values(DidCommProofState).filter(
+  (state) => !DIDCOMM_PROOF_TERMINAL_STATES.includes(state),
+)
+
+/**
+ * OOB purge tracks (INTEGRATION-PLAN-develop.md §4.2, mirroring `credo-data-purge` `purgeOob`):
+ *
+ *   `done`           — terminal, any reusability             → purge past TTL
+ *   `await-response` — non-reusable only                     → purge past TTL
+ *   `await-response` — reusable                              → RETAIN (live invitation URL)
+ *   `initial` / `prepare-response`                           → RETAIN (in-flight)
+ *
+ * A reusable `await-response` record backs an invitation URL that may be printed, embedded in a
+ * QR code, or published; deleting it breaks every future scan of that invitation.
+ */
+export const DIDCOMM_OOB_PURGEABLE_STATES = {
+  terminal: DidCommOutOfBandState.Done as string,
+  stuck: DidCommOutOfBandState.AwaitResponse as string,
+}
+
+/**
+ * Terminal OID4VC session states. The plan only spells out DIDComm state-awareness, but the same
+ * hazard applies: purging by age alone deletes issuance sessions whose holder has not yet
+ * completed the flow, and verification sessions still awaiting a response.
+ */
+export const OID4VC_ISSUANCE_TERMINAL_STATES: string[] = [
+  OpenId4VcIssuanceSessionState.Completed,
+  OpenId4VcIssuanceSessionState.Error,
+]
+
+export const OID4VC_VERIFICATION_TERMINAL_STATES: string[] = [
+  OpenId4VcVerificationSessionState.ResponseVerified,
+  OpenId4VcVerificationSessionState.Error,
+]
+
+/**
+ * Record types the purge must NEVER delete, documented here so the omission reads as a decision
+ * rather than an oversight:
+ *
+ *   `DidCommConnectionRecord` — a live relationship with a holder. Deleting it orphans every
+ *                              credential the holder still holds and breaks all future DIDComm.
+ *   `W3cCredentialRecord`     — the stored credential itself.
+ *   `AnonCredsCredentialRecord`
+ *   `SdJwtVcRecord` / `MdocRecord`
+ *
+ * The last three are what the pre-fix protocol-level delete destroyed as a side effect; see
+ * `PurgeDeleteRecord.ts`.
+ */
+export const NEVER_PURGED_RECORD_TYPES: readonly string[] = [
+  'ConnectionRecord',
+  'W3cCredentialRecord',
+  'AnonCredsCredentialRecord',
+  'SdJwtVcRecord',
+  'MdocRecord',
+]

--- a/src/purge/PurgeStates.ts
+++ b/src/purge/PurgeStates.ts
@@ -9,8 +9,12 @@
  * Every state here is written as a Credo enum member rather than a string literal, so a Credo
  * upgrade that renames or removes a state fails the build instead of silently producing a list
  * that matches nothing (which would make the purge a no-op) or, worse, matches the wrong thing.
- * The non-terminal lists are *derived* by exclusion, so a Credo upgrade that adds a new state
- * automatically classifies it as non-terminal — i.e. fails safe (never purged by the default path).
+ *
+ * Note on derivation: deriving a purgeable list by *exclusion* fails OPEN, not closed — a state
+ * added by a future Credo release would land in it and become purgeable with nobody having reviewed
+ * whether deleting it is safe. So every list the engine actually queries is an explicit allowlist.
+ * Derivation is used only for `DIDCOMM_CREDENTIAL_NON_TERMINAL_STATES`, which exists to be asserted
+ * against and is never queried, and for the coverage check that forces a decision on upgrade.
  */
 import { DidCommCredentialState, DidCommOutOfBandState, DidCommProofState } from '@credo-ts/didcomm'
 import { OpenId4VcIssuanceSessionState, OpenId4VcVerificationSessionState } from '@credo-ts/openid4vc'
@@ -57,6 +61,33 @@ export const DIDCOMM_CREDENTIAL_NON_TERMINAL_STATES: string[] = Object.values(Di
 export const DIDCOMM_PROOF_NON_TERMINAL_STATES: string[] = Object.values(DidCommProofState).filter(
   (state) => !DIDCOMM_PROOF_TERMINAL_STATES.includes(state),
 )
+
+/**
+ * The non-terminal proof states the abandoned sweep is allowed to delete — an explicit allowlist,
+ * NOT the derived list above.
+ *
+ * This sweep is on by default, so derivation would mean a state introduced by a future Credo release
+ * silently became purgeable on upgrade. Enumerating them forces that to be a deliberate decision:
+ * a new state is not purged until someone adds it here, and `PurgeStates.spec.ts` fails the build
+ * until it is classified either way.
+ *
+ * Each entry is a flow that stalled and has no remaining value:
+ *   proposal-sent / proposal-received — a proposal nobody acted on
+ *   request-sent / request-received   — the dominant case: an unanswered proof request
+ *   presentation-sent                 — a presentation the verifier never acknowledged
+ *   presentation-received             — ~0.03% of incomplete proofs in production, and near-empty
+ *                                       in practice because autoAcceptProofs defaults
+ *                                       to ContentApproved, which moves a matching presentation
+ *                                       straight to `done`
+ */
+export const DIDCOMM_PROOF_ABANDONABLE_STATES: string[] = [
+  DidCommProofState.ProposalSent,
+  DidCommProofState.ProposalReceived,
+  DidCommProofState.RequestSent,
+  DidCommProofState.RequestReceived,
+  DidCommProofState.PresentationSent,
+  DidCommProofState.PresentationReceived,
+]
 
 /**
  * OOB purge tracks (INTEGRATION-PLAN-develop.md §4.2, mirroring `credo-data-purge` `purgeOob`):

--- a/src/purge/PurgeTypes.ts
+++ b/src/purge/PurgeTypes.ts
@@ -53,7 +53,17 @@ export interface PurgeCronConfig {
   ttlSeconds: number
   cronSchedule: string
   recordTypes: PurgeRecordType[]
-  /** When true, scan and report but never delete. Defaults to true — deletion is opt-in. */
+  /**
+   * When true, scan and report a census but never delete. Opt-in (default false).
+   *
+   * Not the default, unlike `credo-data-purge`: that tool's dry-run default is safe because an
+   * operator reads the census and immediately re-runs live, whereas a cron job silently doing
+   * nothing while looking enabled means unbounded storage growth found weeks later. What keeps this
+   * job safe is structural — storage-level deletes, state-scoped scans, the retention rules in
+   * `PurgeStates.ts`, and children-before-parent ordering — not the absence of deletion. The mode
+   * exists for the pre-enable census (plan §7 step 5) and for §8's measure-don't-guess decision on
+   * whether the largest tenant needs the batch tool instead.
+   */
   dryRun: boolean
   /** Records processed between throttle sleeps. */
   batchSize: number
@@ -109,9 +119,7 @@ export function buildPurgeConfig(): PurgeConfig | undefined {
       ttlSeconds: parsePositiveInt(process.env.PURGE_CRON_TTL_SECONDS, 'PURGE_CRON_TTL_SECONDS', DEFAULT_TTL_SECONDS),
       cronSchedule: process.env.PURGE_CRON_SCHEDULE || '0 * * * *',
       recordTypes: buildPurgeRecordTypes(),
-      // Fail-safe: only the explicit literal "false" enables deletion. A missing, empty or
-      // misspelled value always falls back to dry-run, matching credo-data-purge's DRY_RUN default.
-      dryRun: process.env.PURGE_CRON_DRY_RUN !== 'false',
+      dryRun: parseStrictBoolean(process.env.PURGE_CRON_DRY_RUN, 'PURGE_CRON_DRY_RUN', false),
       batchSize: parsePositiveInt(process.env.PURGE_CRON_BATCH_SIZE, 'PURGE_CRON_BATCH_SIZE', DEFAULT_BATCH_SIZE),
       throttleMs: parseNonNegativeInt(
         process.env.PURGE_CRON_THROTTLE_MS,
@@ -128,6 +136,21 @@ export function buildPurgeConfig(): PurgeConfig | undefined {
     },
     webhookEnabled: process.env.PURGE_WEBHOOK_ENABLED === 'true',
   }
+}
+
+/**
+ * Strict boolean: accepts only `true`, `false`, or unset/blank. Every other purge boolean is parsed
+ * leniently (`=== 'true'`), which is fine because a typo there lands on the non-destructive side —
+ * the feature simply stays off. `PURGE_CRON_DRY_RUN` is the one flag where lenient parsing would be
+ * asymmetric in the dangerous direction, so a malformed value fails startup rather than silently
+ * picking either mode.
+ */
+function parseStrictBoolean(value: string | undefined, envKey: string, defaultValue: boolean): boolean {
+  const normalized = value?.trim()
+  if (normalized === undefined || normalized === '') return defaultValue
+  if (normalized === 'true') return true
+  if (normalized === 'false') return false
+  throw new Error(`[Purge] ${envKey} must be exactly "true" or "false", got: "${value}"`)
 }
 
 function parsePositiveInt(value: string | undefined, envKey: string, defaultValue: number): number {

--- a/src/purge/PurgeTypes.ts
+++ b/src/purge/PurgeTypes.ts
@@ -117,7 +117,16 @@ export function buildPurgeConfig(): PurgeConfig | undefined {
   const natsEnabled = process.env.PURGE_NATS_ENABLED === 'true'
   const cronEnabled = process.env.PURGE_CRON_ENABLED === 'true'
 
-  if (!natsEnabled && !cronEnabled) return undefined
+  if (!natsEnabled && !cronEnabled) {
+    // Fail loudly rather than returning undefined. cliAgent only validates a truthy config, so
+    // returning undefined here made the validator's own "enable at least one mode" error dead code
+    // and turned a typo in PURGE_CRON_ENABLED into a purge that silently never runs while the master
+    // switch reports it as on.
+    throw new Error(
+      '[Purge] PURGE_ENABLED=true but neither PURGE_NATS_ENABLED nor PURGE_CRON_ENABLED is set to "true". ' +
+        'Enable the cron flow with PURGE_CRON_ENABLED=true, or set PURGE_ENABLED=false to disable purging.',
+    )
+  }
 
   return {
     natsConfig: {

--- a/src/purge/PurgeTypes.ts
+++ b/src/purge/PurgeTypes.ts
@@ -1,9 +1,16 @@
 // Cron defaults live here rather than in PurgeConstants.ts because PurgeConstants imports
 // PurgeRecordType from this module, and `import/no-cycle` is an error in this repo.
-const DEFAULT_TTL_SECONDS = 2_592_000 // 30 days
-const DEFAULT_STALE_PROOF_TTL_SECONDS = 7_776_000 // 90 days — deliberately far more conservative
+const DEFAULT_TTL_SECONDS = 2_592_000 // 30 days — completed flows (audit value)
+const DEFAULT_ABANDONED_TTL_SECONDS = 604_800 // 7 days — dead flows (no value)
 const DEFAULT_BATCH_SIZE = 100 // matches credo-data-purge BATCH_SIZE
 const DEFAULT_THROTTLE_MS = 250 // matches credo-data-purge THROTTLE_MS
+
+/**
+ * Floor on the abandoned TTL. The real hazard is deleting a flow a holder is still responding to,
+ * and that window is minutes, not months — so an hour has ample margin. Overridable for testing via
+ * `PURGE_CRON_ALLOW_SHORT_ABANDONED_TTL`, mirroring credo-data-purge's `STALE_ALLOW_ZERO_TTL`.
+ */
+export const MIN_ABANDONED_TTL_SECONDS = 3_600
 
 export interface NatsConfig {
   servers: string[]
@@ -71,10 +78,25 @@ export interface PurgeCronConfig {
   throttleMs: number
   /** Per-tenant wall-clock budget; 0 disables. A truncated tenant resumes on the next run. */
   timeBudgetMs: number
-  /** Opt-in purge of non-terminal PROOF exchanges. Never applies to credentials. */
+  /**
+   * Purge non-terminal PROOF exchanges against `abandonedTtlSeconds`. On by default: the July 2026
+   * production drain measured `request-sent` at ~68% of all proof exchanges and ~10% of the entire
+   * wallet — making it the single largest contributor to both storage and the
+   * proof-response latency it caused. Never applies to credentials.
+   */
   staleProofEnabled: boolean
-  /** Separate, more conservative TTL for the stale-proof policy. */
-  staleProofTtlSeconds: number
+  /**
+   * TTL for records that represent a *dead* flow rather than a completed one: non-terminal proof
+   * exchanges (when `staleProofEnabled`) and non-reusable `await-response` OOB invitations.
+   *
+   * Deliberately SHORTER than `ttlSeconds`, which is the opposite of what an earlier revision of
+   * this file assumed. A completed exchange is an audit record of a verification that happened and
+   * has retention value; an unanswered proof request or unscanned invitation has none and is of no
+   * use to anyone once it is a few hours old.
+   */
+  abandonedTtlSeconds: number
+  /** Escape hatch allowing `abandonedTtlSeconds` below `MIN_ABANDONED_TTL_SECONDS`. Testing only. */
+  allowShortAbandonedTtl: boolean
 }
 
 export interface PurgeConfig {
@@ -127,12 +149,17 @@ export function buildPurgeConfig(): PurgeConfig | undefined {
         DEFAULT_THROTTLE_MS,
       ),
       timeBudgetMs: parseNonNegativeInt(process.env.PURGE_CRON_TIME_BUDGET_MS, 'PURGE_CRON_TIME_BUDGET_MS', 0),
-      staleProofEnabled: process.env.PURGE_CRON_STALE_PROOF_ENABLED === 'true',
-      staleProofTtlSeconds: parsePositiveInt(
-        process.env.PURGE_CRON_STALE_PROOF_TTL_SECONDS,
-        'PURGE_CRON_STALE_PROOF_TTL_SECONDS',
-        DEFAULT_STALE_PROOF_TTL_SECONDS,
+      staleProofEnabled: parseStrictBoolean(
+        process.env.PURGE_CRON_STALE_PROOF_ENABLED,
+        'PURGE_CRON_STALE_PROOF_ENABLED',
+        true,
       ),
+      abandonedTtlSeconds: parsePositiveInt(
+        process.env.PURGE_CRON_ABANDONED_TTL_SECONDS,
+        'PURGE_CRON_ABANDONED_TTL_SECONDS',
+        DEFAULT_ABANDONED_TTL_SECONDS,
+      ),
+      allowShortAbandonedTtl: process.env.PURGE_CRON_ALLOW_SHORT_ABANDONED_TTL === 'true',
     },
     webhookEnabled: process.env.PURGE_WEBHOOK_ENABLED === 'true',
   }

--- a/src/purge/PurgeTypes.ts
+++ b/src/purge/PurgeTypes.ts
@@ -1,3 +1,10 @@
+// Cron defaults live here rather than in PurgeConstants.ts because PurgeConstants imports
+// PurgeRecordType from this module, and `import/no-cycle` is an error in this repo.
+const DEFAULT_TTL_SECONDS = 2_592_000 // 30 days
+const DEFAULT_STALE_PROOF_TTL_SECONDS = 7_776_000 // 90 days — deliberately far more conservative
+const DEFAULT_BATCH_SIZE = 100 // matches credo-data-purge BATCH_SIZE
+const DEFAULT_THROTTLE_MS = 250 // matches credo-data-purge THROTTLE_MS
+
 export interface NatsConfig {
   servers: string[]
   nkeySeed?: string
@@ -11,6 +18,7 @@ export type AgentMode = 'shared' | 'dedicated'
 export enum PurgeRecordType {
   DIDCOMM_CREDENTIAL = 'didcomm_credential',
   DIDCOMM_PROOF = 'didcomm_proof',
+  DIDCOMM_OOB = 'didcomm_oob',
   OID4VC_ISSUANCE = 'oid4vc_issuance',
   OID4VC_VERIFICATION = 'oid4vc_verification',
 }
@@ -23,23 +31,51 @@ export interface PurgeJob {
   scheduledAt: string
 }
 
+/**
+ * @deprecated The NATS schedule-at-create flow is retained only for reversibility and is dormant by
+ * default (`PURGE_NATS_ENABLED=false`). It fixes the deletion time when the record is *created*, so
+ * it fires state-blind at TTL and can delete records that are still in flight; it also depends on
+ * the JetStream `allow_msg_schedules` feature. Prefer the cron flow, which re-checks state at delete
+ * time. See INTEGRATION-PLAN-develop.md §4.4 — slated for removal once cron parity is proven in prod.
+ */
 export interface PurgeNatsConfig {
   enabled: boolean
   ttlSeconds: number
   nats: NatsConfig
   recordTypes: PurgeRecordType[]
+  /** Operator acknowledgement that this flow deletes records without re-checking their state. */
+  ackStateBlind: boolean
 }
 
 export interface PurgeCronConfig {
   enabled: boolean
+  /** Terminal-state records whose `updatedAt` is older than this are eligible. */
   ttlSeconds: number
   cronSchedule: string
   recordTypes: PurgeRecordType[]
+  /** When true, scan and report but never delete. Defaults to true — deletion is opt-in. */
+  dryRun: boolean
+  /** Records processed between throttle sleeps. */
+  batchSize: number
+  /** Milliseconds slept between batches so the scan cannot monopolise the shared DB pool. */
+  throttleMs: number
+  /** Per-tenant wall-clock budget; 0 disables. A truncated tenant resumes on the next run. */
+  timeBudgetMs: number
+  /** Opt-in purge of non-terminal PROOF exchanges. Never applies to credentials. */
+  staleProofEnabled: boolean
+  /** Separate, more conservative TTL for the stale-proof policy. */
+  staleProofTtlSeconds: number
 }
 
 export interface PurgeConfig {
   natsConfig: PurgeNatsConfig
   cronConfig: PurgeCronConfig
+  /**
+   * @deprecated Per-record HTTP notification. Defaults to false — the receiving platform endpoints
+   * (`/purge/*`) do not exist, and now that the purge no longer deletes stored holder credentials
+   * there is nothing notification-worthy; the per-run audit log is the right level.
+   * See INTEGRATION-PLAN-develop.md §4.5.
+   */
   webhookEnabled: boolean
 }
 
@@ -54,7 +90,7 @@ export function buildPurgeConfig(): PurgeConfig | undefined {
   return {
     natsConfig: {
       enabled: natsEnabled,
-      ttlSeconds: parseTtlSeconds(process.env.PURGE_NATS_TTL_SECONDS, 'PURGE_NATS_TTL_SECONDS'),
+      ttlSeconds: parsePositiveInt(process.env.PURGE_NATS_TTL_SECONDS, 'PURGE_NATS_TTL_SECONDS', DEFAULT_TTL_SECONDS),
       nats: {
         servers: (process.env.NATS_SERVERS || 'nats://localhost:4222')
           .split(',')
@@ -66,22 +102,48 @@ export function buildPurgeConfig(): PurgeConfig | undefined {
         password: process.env.NATS_PASSWORD,
       },
       recordTypes: buildPurgeRecordTypes(),
+      ackStateBlind: process.env.PURGE_NATS_ACK_STATE_BLIND === 'true',
     },
     cronConfig: {
       enabled: cronEnabled,
-      ttlSeconds: parseTtlSeconds(process.env.PURGE_CRON_TTL_SECONDS, 'PURGE_CRON_TTL_SECONDS'),
+      ttlSeconds: parsePositiveInt(process.env.PURGE_CRON_TTL_SECONDS, 'PURGE_CRON_TTL_SECONDS', DEFAULT_TTL_SECONDS),
       cronSchedule: process.env.PURGE_CRON_SCHEDULE || '0 * * * *',
       recordTypes: buildPurgeRecordTypes(),
+      // Fail-safe: only the explicit literal "false" enables deletion. A missing, empty or
+      // misspelled value always falls back to dry-run, matching credo-data-purge's DRY_RUN default.
+      dryRun: process.env.PURGE_CRON_DRY_RUN !== 'false',
+      batchSize: parsePositiveInt(process.env.PURGE_CRON_BATCH_SIZE, 'PURGE_CRON_BATCH_SIZE', DEFAULT_BATCH_SIZE),
+      throttleMs: parseNonNegativeInt(
+        process.env.PURGE_CRON_THROTTLE_MS,
+        'PURGE_CRON_THROTTLE_MS',
+        DEFAULT_THROTTLE_MS,
+      ),
+      timeBudgetMs: parseNonNegativeInt(process.env.PURGE_CRON_TIME_BUDGET_MS, 'PURGE_CRON_TIME_BUDGET_MS', 0),
+      staleProofEnabled: process.env.PURGE_CRON_STALE_PROOF_ENABLED === 'true',
+      staleProofTtlSeconds: parsePositiveInt(
+        process.env.PURGE_CRON_STALE_PROOF_TTL_SECONDS,
+        'PURGE_CRON_STALE_PROOF_TTL_SECONDS',
+        DEFAULT_STALE_PROOF_TTL_SECONDS,
+      ),
     },
-    webhookEnabled: process.env.PURGE_WEBHOOK_ENABLED !== 'false',
+    webhookEnabled: process.env.PURGE_WEBHOOK_ENABLED === 'true',
   }
 }
 
-function parseTtlSeconds(value: string | undefined, envKey: string, defaultSeconds = 2592000): number {
-  if (value === undefined || value === '') return defaultSeconds
+function parsePositiveInt(value: string | undefined, envKey: string, defaultValue: number): number {
+  if (value === undefined || value.trim() === '') return defaultValue
   const parsed = Number(value)
   if (!Number.isInteger(parsed) || parsed <= 0) {
     throw new Error(`[Purge] ${envKey} must be a positive integer, got: "${value}"`)
+  }
+  return parsed
+}
+
+function parseNonNegativeInt(value: string | undefined, envKey: string, defaultValue: number): number {
+  if (value === undefined || value.trim() === '') return defaultValue
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`[Purge] ${envKey} must be a non-negative integer, got: "${value}"`)
   }
   return parsed
 }
@@ -90,6 +152,7 @@ function buildPurgeRecordTypes(): PurgeRecordType[] {
   const envFlags: Record<string, PurgeRecordType> = {
     PURGE_DIDCOMM_CREDENTIAL: PurgeRecordType.DIDCOMM_CREDENTIAL,
     PURGE_DIDCOMM_PROOF: PurgeRecordType.DIDCOMM_PROOF,
+    PURGE_DIDCOMM_OOB: PurgeRecordType.DIDCOMM_OOB,
     PURGE_OID4VC_ISSUANCE: PurgeRecordType.OID4VC_ISSUANCE,
     PURGE_OID4VC_VERIFICATION: PurgeRecordType.OID4VC_VERIFICATION,
   }
@@ -114,6 +177,7 @@ function buildPurgeRecordTypes(): PurgeRecordType[] {
   return [
     PurgeRecordType.DIDCOMM_CREDENTIAL,
     PurgeRecordType.DIDCOMM_PROOF,
+    PurgeRecordType.DIDCOMM_OOB,
     PurgeRecordType.OID4VC_ISSUANCE,
     PurgeRecordType.OID4VC_VERIFICATION,
   ]

--- a/src/purge/PurgeWebhook.ts
+++ b/src/purge/PurgeWebhook.ts
@@ -10,6 +10,21 @@ export enum PurgeDeletionStatus {
   ALREADY_ABSENT = 'already-absent',
 }
 
+/**
+ * @deprecated Per-record purge notification, off by default (`PURGE_WEBHOOK_ENABLED` must be the
+ * literal `true`). Two reasons, per INTEGRATION-PLAN-develop.md §4.5:
+ *
+ *   1. The receiving endpoints (`POST {webhookUrl}/purge/*`) do not exist on the platform. The
+ *      platform's purge notification path is the JetStream `presentation.purged` event consumed by
+ *      `apps/notification/src/nats/jetstream.consumer.ts`, which is a different mechanism entirely.
+ *   2. A per-record push is only meaningful for holder *credential* deletion, which the purge no
+ *      longer performs at all (see `PurgeDeleteRecord.ts`). What remains is issuer/verifier
+ *      transactional cleanup, for which the per-run audit log emitted by `CronPurgeScheduler` is the
+ *      right level.
+ *
+ * Kept only so the decision stays reversible if a receiver is built. Remove once the platform side
+ * is settled.
+ */
 export async function sendPurgeWebhook(
   webhookUrl: string,
   recordId: string,

--- a/src/purge/PurgeWorker.ts
+++ b/src/purge/PurgeWorker.ts
@@ -12,6 +12,16 @@ import { sendPurgeWebhook, PurgeDeletionStatus } from './PurgeWebhook'
 
 const sc = StringCodec()
 
+/**
+ * @deprecated Consumer for the dormant NATS schedule-at-create flow. See `NatsPurgeScheduler` for
+ * why that flow is deprecated, and INTEGRATION-PLAN-develop.md §4.4.
+ *
+ * Note what this worker does *not* do: it deletes whatever record id its job names, without
+ * re-reading the record's state. It now goes through the storage-level delete
+ * (`deletePurgeRecord`), so a purge here no longer destroys the stored holder credential — but it is
+ * still state-blind, and it does not cascade `DidCommMessageRecord` children, so enabling this flow
+ * leaves orphaned messages that only `credo-data-purge`'s orphan sweep can clean up.
+ */
 export class PurgeWorker {
   private recordType: PurgeRecordType
   private consumerName: string

--- a/src/purge/PurgeWorker.ts
+++ b/src/purge/PurgeWorker.ts
@@ -7,7 +7,12 @@ import { RecordNotFoundError } from '@credo-ts/core'
 import { StringCodec } from 'nats'
 
 import { PURGE_CONSUMER_MAX_DELIVER, PURGE_WORKER_RESTART_DELAY_MS } from './PurgeConstants'
-import { deletePurgeRecord } from './PurgeDeleteRecord'
+import {
+  RECORD_TYPES_WITH_DIDCOMM_MESSAGE_CHILDREN,
+  deleteDidCommMessageChildren,
+  deletePurgeRecord,
+  findDidCommMessageChildIds,
+} from './PurgeDeleteRecord'
 import { sendPurgeWebhook, PurgeDeletionStatus } from './PurgeWebhook'
 
 const sc = StringCodec()
@@ -16,11 +21,11 @@ const sc = StringCodec()
  * @deprecated Consumer for the dormant NATS schedule-at-create flow. See `NatsPurgeScheduler` for
  * why that flow is deprecated, and INTEGRATION-PLAN-develop.md §4.4.
  *
- * Note what this worker does *not* do: it deletes whatever record id its job names, without
- * re-reading the record's state. It now goes through the storage-level delete
- * (`deletePurgeRecord`), so a purge here no longer destroys the stored holder credential — but it is
- * still state-blind, and it does not cascade `DidCommMessageRecord` children, so enabling this flow
- * leaves orphaned messages that only `credo-data-purge`'s orphan sweep can clean up.
+ * It shares the cron path's deletion primitives, so a purge here neither destroys the stored holder
+ * credential nor orphans DIDComm messages — the children-before-parent cascade runs here too. What
+ * it still does not do is re-read the record's state before deleting: the job names a record id
+ * fixed at creation time, so this flow remains state-blind and can delete an exchange that is still
+ * in flight. That is the reason it is deprecated and gated behind PURGE_NATS_ACK_STATE_BLIND.
  */
 export class PurgeWorker {
   private recordType: PurgeRecordType
@@ -59,6 +64,19 @@ export class PurgeWorker {
     }
   }
 
+  /**
+   * Children-before-parent, matching the cron engine. `deletePurgeRecord` is parent-only, so without
+   * this every credential/proof purged through the NATS path would leave its `DidCommMessageRecord`s
+   * permanently orphaned — findable only by a full-wallet sweep that the steady-state job never runs.
+   */
+  private async deleteWithCascade(agent: Agent, recordId: string): Promise<void> {
+    if (RECORD_TYPES_WITH_DIDCOMM_MESSAGE_CHILDREN.has(this.recordType)) {
+      const childIds = await findDidCommMessageChildIds(agent, recordId)
+      if (childIds.length > 0) await deleteDidCommMessageChildren(agent, childIds)
+    }
+    await deletePurgeRecord(agent, this.recordType, recordId)
+  }
+
   private async processMessage(msg: any, agent: Agent): Promise<void> {
     let job: PurgeJob | undefined
 
@@ -89,10 +107,10 @@ export class PurgeWorker {
     try {
       if (agentMode === 'shared') {
         await (agent as any).modules.tenants.withTenantAgent({ tenantId }, async (tenantAgent: Agent) => {
-          await deletePurgeRecord(tenantAgent, this.recordType, recordId)
+          await this.deleteWithCascade(tenantAgent, recordId)
         })
       } else {
-        await deletePurgeRecord(agent, this.recordType, recordId)
+        await this.deleteWithCascade(agent, recordId)
       }
 
       logger.info('[Purge] Record deleted', { recordId, recordType, tenantId })

--- a/src/purge/__tests__/PurgeConfig.spec.ts
+++ b/src/purge/__tests__/PurgeConfig.spec.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for purge configuration defaults and startup guards.
+ *
+ * The defaults are the last line of defence for a subsystem that permanently deletes data, so each
+ * one is asserted explicitly:
+ *   - deletion is opt-in (dry-run unless `PURGE_CRON_DRY_RUN=false`)
+ *   - the deprecated per-record webhook is off unless explicitly enabled
+ *   - the deprecated state-blind NATS flow refuses to start without an explicit acknowledgement
+ *   - a stale-proof TTL shorter than the terminal TTL is rejected rather than applied
+ *
+ * Runs under Jest ESM mode (see jest.config.base.ts).
+ */
+import { jest } from '@jest/globals'
+
+// `nats` is imported by PurgeConfigValidator for the JetStream reachability probe. Stub it so the
+// validator's non-NATS branches can be tested without a broker, and so the deprecation guard is
+// proven to fire *before* any connection is attempted.
+const connect = jest.fn(async () => ({
+  jetstreamManager: jest.fn(async () => ({})),
+  close: jest.fn(async () => {}),
+}))
+
+jest.unstable_mockModule('nats', () => ({
+  connect,
+  // Also consumed by `utils/NatsAuthenticator`, which PurgeConfigValidator imports.
+  credsAuthenticator: jest.fn(),
+  nkeyAuthenticator: jest.fn(),
+  usernamePasswordAuthenticator: jest.fn(),
+}))
+
+const { buildPurgeConfig, PurgeRecordType } = await import('../PurgeTypes')
+const { validatePurgeConfig } = await import('../PurgeConfigValidator')
+
+const PURGE_ENV_KEYS = Object.keys(process.env).filter((key) => key.startsWith('PURGE_'))
+
+function withEnv<T>(env: Record<string, string | undefined>, run: () => T): T {
+  const saved = new Map<string, string | undefined>()
+  for (const key of [...PURGE_ENV_KEYS, ...Object.keys(env)]) {
+    saved.set(key, process.env[key])
+    delete process.env[key]
+  }
+  for (const [key, value] of Object.entries(env)) {
+    if (value !== undefined) process.env[key] = value
+  }
+  try {
+    return run()
+  } finally {
+    for (const [key, value] of saved) {
+      if (value === undefined) delete process.env[key]
+      else process.env[key] = value
+    }
+  }
+}
+
+const CRON_ENABLED = { PURGE_ENABLED: 'true', PURGE_CRON_ENABLED: 'true' }
+
+describe('buildPurgeConfig — fail-safe defaults', () => {
+  test('returns undefined unless PURGE_ENABLED is the literal "true"', () => {
+    expect(withEnv({}, buildPurgeConfig)).toBeUndefined()
+    expect(withEnv({ PURGE_ENABLED: 'yes', PURGE_CRON_ENABLED: 'true' }, buildPurgeConfig)).toBeUndefined()
+    // Enabled but with no flow selected is also nothing to do.
+    expect(withEnv({ PURGE_ENABLED: 'true' }, buildPurgeConfig)).toBeUndefined()
+  })
+
+  test('dry-run is the default — only the literal "false" enables deletion', () => {
+    expect(withEnv(CRON_ENABLED, buildPurgeConfig)!.cronConfig.dryRun).toBe(true)
+    // A typo must not silently arm deletion.
+    expect(withEnv({ ...CRON_ENABLED, PURGE_CRON_DRY_RUN: 'no' }, buildPurgeConfig)!.cronConfig.dryRun).toBe(true)
+    expect(withEnv({ ...CRON_ENABLED, PURGE_CRON_DRY_RUN: '' }, buildPurgeConfig)!.cronConfig.dryRun).toBe(true)
+    expect(withEnv({ ...CRON_ENABLED, PURGE_CRON_DRY_RUN: 'false' }, buildPurgeConfig)!.cronConfig.dryRun).toBe(false)
+  })
+
+  test('the deprecated webhook is off unless explicitly enabled', () => {
+    expect(withEnv(CRON_ENABLED, buildPurgeConfig)!.webhookEnabled).toBe(false)
+    expect(withEnv({ ...CRON_ENABLED, PURGE_WEBHOOK_ENABLED: 'true' }, buildPurgeConfig)!.webhookEnabled).toBe(true)
+  })
+
+  test('batching, throttle and TTL defaults match the validated batch tool', () => {
+    const { cronConfig } = withEnv(CRON_ENABLED, buildPurgeConfig)!
+
+    expect(cronConfig.ttlSeconds).toBe(2_592_000) // 30 days
+    expect(cronConfig.batchSize).toBe(100)
+    expect(cronConfig.throttleMs).toBe(250)
+    expect(cronConfig.timeBudgetMs).toBe(0) // unbudgeted unless an operator opts in
+    expect(cronConfig.staleProofEnabled).toBe(false)
+    expect(cronConfig.staleProofTtlSeconds).toBe(7_776_000) // 90 days
+  })
+
+  test('all five record types are purged by default, and flags narrow the set', () => {
+    expect(withEnv(CRON_ENABLED, buildPurgeConfig)!.cronConfig.recordTypes).toEqual([
+      PurgeRecordType.DIDCOMM_CREDENTIAL,
+      PurgeRecordType.DIDCOMM_PROOF,
+      PurgeRecordType.DIDCOMM_OOB,
+      PurgeRecordType.OID4VC_ISSUANCE,
+      PurgeRecordType.OID4VC_VERIFICATION,
+    ])
+
+    const narrowed = withEnv({ ...CRON_ENABLED, PURGE_DIDCOMM_OOB: 'true' }, buildPurgeConfig)!
+    expect(narrowed.cronConfig.recordTypes).toEqual([PurgeRecordType.DIDCOMM_OOB])
+  })
+
+  test('rejects non-positive and malformed numeric settings instead of falling back silently', () => {
+    for (const value of ['0', '-1', 'abc', '1.5']) {
+      expect(() => withEnv({ ...CRON_ENABLED, PURGE_CRON_TTL_SECONDS: value }, buildPurgeConfig)).toThrow(
+        /PURGE_CRON_TTL_SECONDS/,
+      )
+    }
+    // A zero throttle is legitimate (disables the sleep); a negative one is not.
+    expect(withEnv({ ...CRON_ENABLED, PURGE_CRON_THROTTLE_MS: '0' }, buildPurgeConfig)!.cronConfig.throttleMs).toBe(0)
+    expect(() => withEnv({ ...CRON_ENABLED, PURGE_CRON_THROTTLE_MS: '-1' }, buildPurgeConfig)).toThrow(
+      /PURGE_CRON_THROTTLE_MS/,
+    )
+  })
+})
+
+describe('validatePurgeConfig — startup guards', () => {
+  beforeEach(() => {
+    connect.mockClear()
+  })
+
+  test('accepts a cron-only configuration', async () => {
+    const config = withEnv(CRON_ENABLED, buildPurgeConfig)!
+    await expect(validatePurgeConfig(config)).resolves.toBeUndefined()
+    expect(connect).not.toHaveBeenCalled()
+  })
+
+  test('rejects a stale-proof TTL shorter than the terminal TTL', async () => {
+    const config = withEnv(
+      {
+        ...CRON_ENABLED,
+        PURGE_CRON_STALE_PROOF_ENABLED: 'true',
+        PURGE_CRON_TTL_SECONDS: '2592000',
+        PURGE_CRON_STALE_PROOF_TTL_SECONDS: '86400',
+      },
+      buildPurgeConfig,
+    )!
+
+    // Purging in-flight verifications sooner than completed ones is always a misconfiguration.
+    await expect(validatePurgeConfig(config)).rejects.toThrow(/must be >=/)
+  })
+
+  test('refuses the deprecated NATS flow unless the state-blind behaviour is acknowledged', async () => {
+    const config = withEnv({ PURGE_ENABLED: 'true', PURGE_NATS_ENABLED: 'true' }, buildPurgeConfig)!
+
+    await expect(validatePurgeConfig(config)).rejects.toThrow(/deprecated and refused by default/)
+    // The guard must fire before any broker connection is attempted.
+    expect(connect).not.toHaveBeenCalled()
+  })
+
+  test('allows the NATS flow once acknowledged, and then probes JetStream', async () => {
+    const config = withEnv(
+      { PURGE_ENABLED: 'true', PURGE_NATS_ENABLED: 'true', PURGE_NATS_ACK_STATE_BLIND: 'true' },
+      buildPurgeConfig,
+    )!
+
+    await expect(validatePurgeConfig(config)).resolves.toBeUndefined()
+    expect(connect).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/purge/__tests__/PurgeConfig.spec.ts
+++ b/src/purge/__tests__/PurgeConfig.spec.ts
@@ -62,12 +62,23 @@ describe('buildPurgeConfig — fail-safe defaults', () => {
     expect(withEnv({ PURGE_ENABLED: 'true' }, buildPurgeConfig)).toBeUndefined()
   })
 
-  test('dry-run is the default — only the literal "false" enables deletion', () => {
-    expect(withEnv(CRON_ENABLED, buildPurgeConfig)!.cronConfig.dryRun).toBe(true)
-    // A typo must not silently arm deletion.
-    expect(withEnv({ ...CRON_ENABLED, PURGE_CRON_DRY_RUN: 'no' }, buildPurgeConfig)!.cronConfig.dryRun).toBe(true)
-    expect(withEnv({ ...CRON_ENABLED, PURGE_CRON_DRY_RUN: '' }, buildPurgeConfig)!.cronConfig.dryRun).toBe(true)
+  test('an enabled cron purge deletes — dry-run is an opt-in census mode, not the default', () => {
+    // Enabling the purge is already a two-flag statement of intent; a third flag standing between
+    // "enabled" and "actually deleting" would let the job look healthy while data grew unbounded.
+    expect(withEnv(CRON_ENABLED, buildPurgeConfig)!.cronConfig.dryRun).toBe(false)
+    expect(withEnv({ ...CRON_ENABLED, PURGE_CRON_DRY_RUN: '' }, buildPurgeConfig)!.cronConfig.dryRun).toBe(false)
     expect(withEnv({ ...CRON_ENABLED, PURGE_CRON_DRY_RUN: 'false' }, buildPurgeConfig)!.cronConfig.dryRun).toBe(false)
+    expect(withEnv({ ...CRON_ENABLED, PURGE_CRON_DRY_RUN: 'true' }, buildPurgeConfig)!.cronConfig.dryRun).toBe(true)
+  })
+
+  test('a malformed PURGE_CRON_DRY_RUN fails startup instead of silently picking a mode', () => {
+    // The one boolean whose lenient parsing would be asymmetric in the dangerous direction, so it
+    // is strict in BOTH directions rather than trading one silent failure for another.
+    for (const value of ['no', 'ture', 'TRUE', '1', 'yes']) {
+      expect(() => withEnv({ ...CRON_ENABLED, PURGE_CRON_DRY_RUN: value }, buildPurgeConfig)).toThrow(
+        /PURGE_CRON_DRY_RUN must be exactly "true" or "false"/,
+      )
+    }
   })
 
   test('the deprecated webhook is off unless explicitly enabled', () => {

--- a/src/purge/__tests__/PurgeConfig.spec.ts
+++ b/src/purge/__tests__/PurgeConfig.spec.ts
@@ -147,6 +147,17 @@ describe('validatePurgeConfig — startup guards', () => {
     await expect(validatePurgeConfig(config)).resolves.toBeUndefined()
   })
 
+  test('rejects an invalid cron expression with a message that names the setting', async () => {
+    // node-cron only validates when the task is created, and fails with a bare
+    // "Cannot read properties of undefined (reading 'replace')" — a crashed agent and no clue why.
+    const config = withEnv({ ...CRON_ENABLED, PURGE_CRON_SCHEDULE: 'every day at 3' }, buildPurgeConfig)!
+
+    await expect(validatePurgeConfig(config)).rejects.toThrow(/PURGE_CRON_SCHEDULE is not a valid cron expression/)
+
+    const valid = withEnv({ ...CRON_ENABLED, PURGE_CRON_SCHEDULE: '0 3 * * *' }, buildPurgeConfig)!
+    await expect(validatePurgeConfig(valid)).resolves.toBeUndefined()
+  })
+
   test('rejects an abandoned TTL below the safety floor unless explicitly overridden', async () => {
     const tooShort = { ...CRON_ENABLED, PURGE_CRON_ABANDONED_TTL_SECONDS: '60' }
 

--- a/src/purge/__tests__/PurgeConfig.spec.ts
+++ b/src/purge/__tests__/PurgeConfig.spec.ts
@@ -58,8 +58,18 @@ describe('buildPurgeConfig — fail-safe defaults', () => {
   test('returns undefined unless PURGE_ENABLED is the literal "true"', () => {
     expect(withEnv({}, buildPurgeConfig)).toBeUndefined()
     expect(withEnv({ PURGE_ENABLED: 'yes', PURGE_CRON_ENABLED: 'true' }, buildPurgeConfig)).toBeUndefined()
-    // Enabled but with no flow selected is also nothing to do.
-    expect(withEnv({ PURGE_ENABLED: 'true' }, buildPurgeConfig)).toBeUndefined()
+  })
+
+  test('PURGE_ENABLED=true with no flow selected fails loudly rather than silently doing nothing', () => {
+    // Previously this returned undefined, and cliAgent only validates a truthy config — so the
+    // validator's own "enable at least one mode" error was unreachable and a typo in
+    // PURGE_CRON_ENABLED produced a purge that never ran while the master switch reported it on.
+    expect(() => withEnv({ PURGE_ENABLED: 'true' }, buildPurgeConfig)).toThrow(
+      /neither PURGE_NATS_ENABLED nor PURGE_CRON_ENABLED/,
+    )
+    expect(() => withEnv({ PURGE_ENABLED: 'true', PURGE_CRON_ENABLED: 'ture' }, buildPurgeConfig)).toThrow(
+      /neither PURGE_NATS_ENABLED nor PURGE_CRON_ENABLED/,
+    )
   })
 
   test('an enabled cron purge deletes — dry-run is an opt-in census mode, not the default', () => {

--- a/src/purge/__tests__/PurgeConfig.spec.ts
+++ b/src/purge/__tests__/PurgeConfig.spec.ts
@@ -3,10 +3,10 @@
  *
  * The defaults are the last line of defence for a subsystem that permanently deletes data, so each
  * one is asserted explicitly:
- *   - deletion is opt-in (dry-run unless `PURGE_CRON_DRY_RUN=false`)
+ *   - an enabled purge actually deletes; dry-run is an opt-in census, and malformed values fail fast
  *   - the deprecated per-record webhook is off unless explicitly enabled
  *   - the deprecated state-blind NATS flow refuses to start without an explicit acknowledgement
- *   - a stale-proof TTL shorter than the terminal TTL is rejected rather than applied
+ *   - an abandoned TTL below the safety floor is rejected rather than applied
  *
  * Runs under Jest ESM mode (see jest.config.base.ts).
  */
@@ -93,8 +93,9 @@ describe('buildPurgeConfig — fail-safe defaults', () => {
     expect(cronConfig.batchSize).toBe(100)
     expect(cronConfig.throttleMs).toBe(250)
     expect(cronConfig.timeBudgetMs).toBe(0) // unbudgeted unless an operator opts in
-    expect(cronConfig.staleProofEnabled).toBe(false)
-    expect(cronConfig.staleProofTtlSeconds).toBe(7_776_000) // 90 days
+    expect(cronConfig.staleProofEnabled).toBe(true) // request-sent was 68% of prod proof volume
+    expect(cronConfig.abandonedTtlSeconds).toBe(604_800) // 7 days — shorter than the 30-day terminal TTL
+    expect(cronConfig.abandonedTtlSeconds).toBeLessThan(cronConfig.ttlSeconds)
   })
 
   test('all five record types are purged by default, and flags narrow the set', () => {
@@ -135,19 +136,25 @@ describe('validatePurgeConfig — startup guards', () => {
     expect(connect).not.toHaveBeenCalled()
   })
 
-  test('rejects a stale-proof TTL shorter than the terminal TTL', async () => {
+  test('accepts an abandoned TTL shorter than the terminal TTL — that is the intended shape', async () => {
     const config = withEnv(
-      {
-        ...CRON_ENABLED,
-        PURGE_CRON_STALE_PROOF_ENABLED: 'true',
-        PURGE_CRON_TTL_SECONDS: '2592000',
-        PURGE_CRON_STALE_PROOF_TTL_SECONDS: '86400',
-      },
+      { ...CRON_ENABLED, PURGE_CRON_TTL_SECONDS: '2592000', PURGE_CRON_ABANDONED_TTL_SECONDS: '604800' },
       buildPurgeConfig,
     )!
 
-    // Purging in-flight verifications sooner than completed ones is always a misconfiguration.
-    await expect(validatePurgeConfig(config)).rejects.toThrow(/must be >=/)
+    // Dead requests are purged sooner than completed exchanges by design. An earlier revision
+    // rejected this configuration outright, which made the production-derived policy unreachable.
+    await expect(validatePurgeConfig(config)).resolves.toBeUndefined()
+  })
+
+  test('rejects an abandoned TTL below the safety floor unless explicitly overridden', async () => {
+    const tooShort = { ...CRON_ENABLED, PURGE_CRON_ABANDONED_TTL_SECONDS: '60' }
+
+    // The floor guards the only real hazard: deleting a flow a holder is mid-response to.
+    await expect(validatePurgeConfig(withEnv(tooShort, buildPurgeConfig)!)).rejects.toThrow(/below the 3600s floor/)
+
+    const overridden = withEnv({ ...tooShort, PURGE_CRON_ALLOW_SHORT_ABANDONED_TTL: 'true' }, buildPurgeConfig)!
+    await expect(validatePurgeConfig(overridden)).resolves.toBeUndefined()
   })
 
   test('refuses the deprecated NATS flow unless the state-blind behaviour is acknowledged', async () => {

--- a/src/purge/__tests__/PurgeDeleteRecord.spec.ts
+++ b/src/purge/__tests__/PurgeDeleteRecord.spec.ts
@@ -1,0 +1,216 @@
+/**
+ * Regression tests for the §4.1 credential-safety fix (INTEGRATION-PLAN-develop.md).
+ *
+ * The hazard being locked down: `DidCommBaseCredentialProtocol.delete()` defaults
+ * `deleteAssociatedCredentials` to `true`, so the protocol-level delete the purge previously used
+ * (`agent.modules.didcomm.credentials.deleteById(id)`) also destroyed the stored
+ * `W3cCredentialRecord` / `AnonCredsCredentialRecord`. For a holder cloud wallet that is data loss.
+ *
+ * These tests assert that a purge deletes the exchange record through the `StorageService` and
+ * touches nothing else — in particular that the protocol APIs are never called.
+ *
+ * Runs under Jest ESM mode (see jest.config.base.ts).
+ */
+import { jest } from '@jest/globals'
+
+const { InjectionSymbols, RecordNotFoundError } = await import('@credo-ts/core')
+const { DidCommCredentialExchangeRecord, DidCommMessageRecord, DidCommOutOfBandRecord, DidCommProofExchangeRecord } =
+  await import('@credo-ts/didcomm')
+const { OpenId4VcIssuanceSessionRepository, OpenId4VcVerificationSessionRepository } =
+  await import('@credo-ts/openid4vc')
+const {
+  RECORD_TYPES_WITH_DIDCOMM_MESSAGE_CHILDREN,
+  deleteDidCommMessageChildren,
+  deletePurgeRecord,
+  findDidCommMessageChildIds,
+} = await import('../PurgeDeleteRecord')
+const { PurgeRecordType } = await import('../PurgeTypes')
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+const AGENT_CONTEXT = { contextCorrelationId: 'tenant-abc' }
+
+interface Harness {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  agent: any
+  storageService: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    deleteById: jest.Mock<any>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    findByQuery: jest.Mock<any>
+  }
+  protocolApis: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    credentialsDeleteById: jest.Mock<any>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    proofsDeleteById: jest.Mock<any>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    oobDeleteById: jest.Mock<any>
+  }
+  repositories: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    issuanceDeleteById: jest.Mock<any>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    verificationDeleteById: jest.Mock<any>
+  }
+}
+
+function makeHarness(messages: Array<{ id: string }> = []): Harness {
+  const storageService = {
+    deleteById: jest.fn(async () => {}),
+    findByQuery: jest.fn(async () => messages),
+  }
+  const protocolApis = {
+    credentialsDeleteById: jest.fn(async () => {}),
+    proofsDeleteById: jest.fn(async () => {}),
+    oobDeleteById: jest.fn(async () => {}),
+  }
+  const repositories = {
+    issuanceDeleteById: jest.fn(async () => {}),
+    verificationDeleteById: jest.fn(async () => {}),
+  }
+
+  const agent = {
+    context: AGENT_CONTEXT,
+    dependencyManager: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      resolve: (token: any) => {
+        if (token === InjectionSymbols.StorageService) return storageService
+        if (token === OpenId4VcIssuanceSessionRepository) return { deleteById: repositories.issuanceDeleteById }
+        if (token === OpenId4VcVerificationSessionRepository) return { deleteById: repositories.verificationDeleteById }
+        throw new Error(`unexpected token: ${String(token)}`)
+      },
+    },
+    modules: {
+      didcomm: {
+        credentials: { deleteById: protocolApis.credentialsDeleteById },
+        proofs: { deleteById: protocolApis.proofsDeleteById },
+        oob: { deleteById: protocolApis.oobDeleteById },
+      },
+    },
+  }
+
+  return { agent, storageService, protocolApis, repositories }
+}
+
+function expectNoProtocolDeletes(harness: Harness) {
+  expect(harness.protocolApis.credentialsDeleteById).not.toHaveBeenCalled()
+  expect(harness.protocolApis.proofsDeleteById).not.toHaveBeenCalled()
+  expect(harness.protocolApis.oobDeleteById).not.toHaveBeenCalled()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('deletePurgeRecord — storage-level deletes only (§4.1)', () => {
+  test('credential exchange: deletes the exchange record via StorageService, never via the protocol API', async () => {
+    const harness = makeHarness()
+
+    await deletePurgeRecord(harness.agent, PurgeRecordType.DIDCOMM_CREDENTIAL, 'cred-exchange-1')
+
+    expect(harness.storageService.deleteById).toHaveBeenCalledTimes(1)
+    expect(harness.storageService.deleteById).toHaveBeenCalledWith(
+      AGENT_CONTEXT,
+      DidCommCredentialExchangeRecord,
+      'cred-exchange-1',
+    )
+
+    // The whole point of the fix: the protocol delete (which cascades into the stored credential)
+    // must never be reached.
+    expectNoProtocolDeletes(harness)
+  })
+
+  test('credential exchange: no W3c / AnonCreds credential record is ever deleted', async () => {
+    const harness = makeHarness()
+
+    await deletePurgeRecord(harness.agent, PurgeRecordType.DIDCOMM_CREDENTIAL, 'cred-exchange-1')
+
+    // Only ONE delete happened, and it named the exchange record class. Any cascade into a stored
+    // credential would have to go through either an extra storage delete with a different record
+    // class, or the protocol API — both of which are asserted absent.
+    const deletedClasses = harness.storageService.deleteById.mock.calls.map((call) => call[1])
+    expect(deletedClasses).toEqual([DidCommCredentialExchangeRecord])
+    for (const recordClass of deletedClasses) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((recordClass as any).type).toBe('CredentialRecord')
+    }
+    expectNoProtocolDeletes(harness)
+  })
+
+  test('proof exchange: deletes via StorageService with the proof record class', async () => {
+    const harness = makeHarness()
+
+    await deletePurgeRecord(harness.agent, PurgeRecordType.DIDCOMM_PROOF, 'proof-1')
+
+    expect(harness.storageService.deleteById).toHaveBeenCalledWith(AGENT_CONTEXT, DidCommProofExchangeRecord, 'proof-1')
+    expectNoProtocolDeletes(harness)
+  })
+
+  test('OOB: deletes via StorageService with the OOB record class', async () => {
+    const harness = makeHarness()
+
+    await deletePurgeRecord(harness.agent, PurgeRecordType.DIDCOMM_OOB, 'oob-1')
+
+    expect(harness.storageService.deleteById).toHaveBeenCalledWith(AGENT_CONTEXT, DidCommOutOfBandRecord, 'oob-1')
+    expectNoProtocolDeletes(harness)
+  })
+
+  test('OID4VC issuance/verification: stay on their repositories, which are already parent-only', async () => {
+    const harness = makeHarness()
+
+    await deletePurgeRecord(harness.agent, PurgeRecordType.OID4VC_ISSUANCE, 'issuance-1')
+    await deletePurgeRecord(harness.agent, PurgeRecordType.OID4VC_VERIFICATION, 'verification-1')
+
+    expect(harness.repositories.issuanceDeleteById).toHaveBeenCalledWith(AGENT_CONTEXT, 'issuance-1')
+    expect(harness.repositories.verificationDeleteById).toHaveBeenCalledWith(AGENT_CONTEXT, 'verification-1')
+    expect(harness.storageService.deleteById).not.toHaveBeenCalled()
+  })
+
+  test('propagates RecordNotFoundError so callers can treat "already gone" as idempotent success', async () => {
+    const harness = makeHarness()
+    harness.storageService.deleteById.mockImplementation(async () => {
+      throw new RecordNotFoundError('gone', { recordType: 'CredentialRecord' })
+    })
+
+    await expect(deletePurgeRecord(harness.agent, PurgeRecordType.DIDCOMM_CREDENTIAL, 'cred-1')).rejects.toBeInstanceOf(
+      RecordNotFoundError,
+    )
+  })
+})
+
+describe('DidCommMessageRecord cascade', () => {
+  test('only credential and proof exchanges own message children', () => {
+    expect(RECORD_TYPES_WITH_DIDCOMM_MESSAGE_CHILDREN.has(PurgeRecordType.DIDCOMM_CREDENTIAL)).toBe(true)
+    expect(RECORD_TYPES_WITH_DIDCOMM_MESSAGE_CHILDREN.has(PurgeRecordType.DIDCOMM_PROOF)).toBe(true)
+    // OOB carries its invitation inline; the OID4VC sessions are not DIDComm at all. Querying for
+    // children there would be a wasted round-trip per record on the largest category.
+    expect(RECORD_TYPES_WITH_DIDCOMM_MESSAGE_CHILDREN.has(PurgeRecordType.DIDCOMM_OOB)).toBe(false)
+    expect(RECORD_TYPES_WITH_DIDCOMM_MESSAGE_CHILDREN.has(PurgeRecordType.OID4VC_ISSUANCE)).toBe(false)
+    expect(RECORD_TYPES_WITH_DIDCOMM_MESSAGE_CHILDREN.has(PurgeRecordType.OID4VC_VERIFICATION)).toBe(false)
+  })
+
+  test('children are looked up by the associatedRecordId tag', async () => {
+    const harness = makeHarness([{ id: 'msg-1' }, { id: 'msg-2' }])
+
+    const childIds = await findDidCommMessageChildIds(harness.agent, 'cred-exchange-1')
+
+    expect(harness.storageService.findByQuery).toHaveBeenCalledWith(AGENT_CONTEXT, DidCommMessageRecord, {
+      associatedRecordId: 'cred-exchange-1',
+    })
+    expect(childIds).toEqual(['msg-1', 'msg-2'])
+  })
+
+  test('children are deleted as DidCommMessageRecords', async () => {
+    const harness = makeHarness()
+
+    await deleteDidCommMessageChildren(harness.agent, ['msg-1', 'msg-2'])
+
+    expect(harness.storageService.deleteById.mock.calls).toEqual([
+      [AGENT_CONTEXT, DidCommMessageRecord, 'msg-1'],
+      [AGENT_CONTEXT, DidCommMessageRecord, 'msg-2'],
+    ])
+  })
+})

--- a/src/purge/__tests__/PurgeDeleteRecord.spec.ts
+++ b/src/purge/__tests__/PurgeDeleteRecord.spec.ts
@@ -13,8 +13,8 @@
  */
 import { jest } from '@jest/globals'
 
-const { InjectionSymbols, RecordNotFoundError, W3cCredentialRepository } = await import('@credo-ts/core')
-const { DidCommCredentialExchangeRecord, DidCommMessageRecord, DidCommOutOfBandRecord, DidCommProofExchangeRecord } =
+const { RecordNotFoundError, W3cCredentialRepository } = await import('@credo-ts/core')
+const { DidCommCredentialExchangeRepository, DidCommMessageRepository, DidCommProofExchangeRepository } =
   await import('@credo-ts/didcomm')
 const { OpenId4VcIssuanceSessionRepository, OpenId4VcVerificationSessionRepository } =
   await import('@credo-ts/openid4vc')
@@ -23,6 +23,7 @@ const {
   deleteDidCommMessageChildren,
   deletePurgeRecord,
   findDidCommMessageChildIds,
+  findPurgeRecordById,
 } = await import('../PurgeDeleteRecord')
 const { PurgeRecordType } = await import('../PurgeTypes')
 
@@ -32,52 +33,36 @@ const { PurgeRecordType } = await import('../PurgeTypes')
 
 const AGENT_CONTEXT = { contextCorrelationId: 'tenant-abc' }
 
-interface Harness {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  agent: any
-  storageService: {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    deleteById: jest.Mock<any>
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    findByQuery: jest.Mock<any>
-  }
-  protocolApis: {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    credentialsDeleteById: jest.Mock<any>
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    proofsDeleteById: jest.Mock<any>
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    oobDeleteById: jest.Mock<any>
-  }
-  repositories: {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    issuanceDeleteById: jest.Mock<any>
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    verificationDeleteById: jest.Mock<any>
-    /** The holder's stored JSON-LD credential. Must never be reached. */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    w3cDelete: jest.Mock<any>
-  }
-  /** Tokens the code under test asked the container for. */
-  resolved: unknown[]
-}
+function makeHarness(messages: Array<{ id: string }> = []) {
+  const calls: Array<{ repo: string; op: string; id: string }> = []
+  const resolved: unknown[] = []
+  const deleteErrors: Record<string, Error> = {}
 
-function makeHarness(messages: Array<{ id: string }> = []): Harness {
-  const storageService = {
-    deleteById: jest.fn(async () => {}),
+  const repo = (name: string) => ({
+    deleteById: jest.fn(async (_ctx: unknown, id: string) => {
+      const error = deleteErrors[id]
+      if (error) throw error
+      calls.push({ repo: name, op: 'delete', id })
+    }),
+    findById: jest.fn(async (_ctx: unknown, id: string) => ({ id })),
     findByQuery: jest.fn(async () => messages),
-  }
+  })
+
+  const credentials = repo('credentialExchange')
+  const proofs = repo('proofExchange')
+  const didcommMessages = repo('didcommMessage')
+  const issuance = repo('oid4vcIssuance')
+  const verification = repo('oid4vcVerification')
+  const w3c = repo('w3cCredential')
+
+  // Protocol-layer entry points. Reaching ANY of these is the bug this file exists to prevent.
   const protocolApis = {
     credentialsDeleteById: jest.fn(async () => {}),
     proofsDeleteById: jest.fn(async () => {}),
-    oobDeleteById: jest.fn(async () => {}),
   }
-  const repositories = {
-    issuanceDeleteById: jest.fn(async () => {}),
-    verificationDeleteById: jest.fn(async () => {}),
-    w3cDelete: jest.fn(async () => {}),
-  }
-  const resolved: unknown[] = []
+  // The OOB API is the one exception: it must be used, for the mediator routing cleanup.
+  const oobDeleteById = jest.fn(async () => {})
+  const oobFindById = jest.fn(async (id: string) => ({ id }))
 
   const agent = {
     context: AGENT_CONTEXT,
@@ -85,10 +70,12 @@ function makeHarness(messages: Array<{ id: string }> = []): Harness {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       resolve: (token: any) => {
         resolved.push(token)
-        if (token === InjectionSymbols.StorageService) return storageService
-        if (token === OpenId4VcIssuanceSessionRepository) return { deleteById: repositories.issuanceDeleteById }
-        if (token === OpenId4VcVerificationSessionRepository) return { deleteById: repositories.verificationDeleteById }
-        if (token === W3cCredentialRepository) return { delete: repositories.w3cDelete, findById: jest.fn() }
+        if (token === DidCommCredentialExchangeRepository) return credentials
+        if (token === DidCommProofExchangeRepository) return proofs
+        if (token === DidCommMessageRepository) return didcommMessages
+        if (token === OpenId4VcIssuanceSessionRepository) return issuance
+        if (token === OpenId4VcVerificationSessionRepository) return verification
+        if (token === W3cCredentialRepository) return w3c
         throw new Error(`unexpected token: ${String(token)}`)
       },
     },
@@ -96,130 +83,111 @@ function makeHarness(messages: Array<{ id: string }> = []): Harness {
       didcomm: {
         credentials: { deleteById: protocolApis.credentialsDeleteById },
         proofs: { deleteById: protocolApis.proofsDeleteById },
-        oob: { deleteById: protocolApis.oobDeleteById },
+        oob: { deleteById: oobDeleteById, findById: oobFindById },
       },
     },
   }
 
-  return { agent, storageService, protocolApis, repositories, resolved }
+  return {
+    agent,
+    calls,
+    resolved,
+    deleteErrors,
+    repos: { credentials, proofs, didcommMessages, issuance, verification, w3c },
+    protocolApis,
+    oobDeleteById,
+    oobFindById,
+  }
 }
 
-function expectNoProtocolDeletes(harness: Harness) {
+type Harness = ReturnType<typeof makeHarness>
+
+function expectNoProtocolCredentialDeletes(harness: Harness) {
   expect(harness.protocolApis.credentialsDeleteById).not.toHaveBeenCalled()
   expect(harness.protocolApis.proofsDeleteById).not.toHaveBeenCalled()
-  expect(harness.protocolApis.oobDeleteById).not.toHaveBeenCalled()
+  expect(harness.repos.w3c.deleteById).not.toHaveBeenCalled()
+  expect(harness.resolved).not.toContain(W3cCredentialRepository)
 }
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('deletePurgeRecord — storage-level deletes only (§4.1)', () => {
-  test('credential exchange: deletes the exchange record via StorageService, never via the protocol API', async () => {
-    const harness = makeHarness()
-
-    await deletePurgeRecord(harness.agent, PurgeRecordType.DIDCOMM_CREDENTIAL, 'cred-exchange-1')
-
-    expect(harness.storageService.deleteById).toHaveBeenCalledTimes(1)
-    expect(harness.storageService.deleteById).toHaveBeenCalledWith(
-      AGENT_CONTEXT,
-      DidCommCredentialExchangeRecord,
-      'cred-exchange-1',
-    )
-
-    // The whole point of the fix: the protocol delete (which cascades into the stored credential)
-    // must never be reached.
-    expectNoProtocolDeletes(harness)
-  })
-
-  test('credential exchange: no W3c / AnonCreds credential record is ever deleted', async () => {
-    const harness = makeHarness()
-
-    await deletePurgeRecord(harness.agent, PurgeRecordType.DIDCOMM_CREDENTIAL, 'cred-exchange-1')
-
-    // Only ONE delete happened, and it named the exchange record class. Any cascade into a stored
-    // credential would have to go through either an extra storage delete with a different record
-    // class, or the protocol API — both of which are asserted absent.
-    const deletedClasses = harness.storageService.deleteById.mock.calls.map((call) => call[1])
-    expect(deletedClasses).toEqual([DidCommCredentialExchangeRecord])
-    for (const recordClass of deletedClasses) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect((recordClass as any).type).toBe('CredentialRecord')
-    }
-    expectNoProtocolDeletes(harness)
-  })
-
+describe('deletePurgeRecord — parent-only, never the credential-cascading protocol layer (§4.1)', () => {
   test('JSON-LD over DIDComm: the holder\u2019s stored W3cCredentialRecord is never reached', async () => {
-    // This is the exact production stack (JSON-LD credentials over DIDComm, holder cloud wallet) and
-    // the exact chain the old protocol delete followed:
-    //
+    // The exact production stack, and the exact chain the old protocol delete followed:
     //   credentials.deleteById(id)
-    //     -> DidCommCredentialV2Protocol.delete()            deleteAssociatedCredentials ?? true
-    //     -> getFormatServiceForRecordType('w3c')            FIRST format service claiming 'w3c',
-    //                                                        which in cliAgent.ts is legacyIndy,
-    //                                                        NOT the JSON-LD service
+    //     -> DidCommCredentialV2Protocol.delete()        deleteAssociatedCredentials ?? true
+    //     -> getFormatServiceForRecordType('w3c')        FIRST service claiming 'w3c', which in
+    //                                                    cliAgent.ts is legacyIndy, NOT jsonLd
     //     -> AnonCredsRsHolderService.deleteCredential(id)
-    //     -> W3cCredentialRepository.findById(id) hits       the binding IS a W3cCredentialRecord id
-    //     -> W3cCredentialRepository.delete(...)             holder's credential destroyed
-    //
-    // Note the JSON-LD format service's own deleteCredentialById() throws 'Not implemented', so it
-    // would have been harmless — but it never runs, because legacyIndy is registered first and also
-    // declares credentialRecordType 'w3c'. There was no accidental protection.
+    //     -> W3cCredentialRepository.findById(id) hits   the binding IS a W3cCredentialRecord id
+    //     -> W3cCredentialRepository.delete(...)         holder's credential destroyed
     const harness = makeHarness()
-    // The binding the exchange record would carry for an issued JSON-LD credential.
-    const exchangeRecordId = 'cred-exchange-1'
 
-    await deletePurgeRecord(harness.agent, PurgeRecordType.DIDCOMM_CREDENTIAL, exchangeRecordId)
+    await deletePurgeRecord(harness.agent as never, PurgeRecordType.DIDCOMM_CREDENTIAL, 'cred-exchange-1')
 
-    // The stored credential's repository is never even asked for, let alone called.
-    expect(harness.resolved).not.toContain(W3cCredentialRepository)
-    expect(harness.repositories.w3cDelete).not.toHaveBeenCalled()
-    // And the protocol entry point that starts the chain is never invoked.
-    expectNoProtocolDeletes(harness)
-    // Exactly one delete, naming the exchange record class.
-    expect(harness.storageService.deleteById.mock.calls).toEqual([
-      [AGENT_CONTEXT, DidCommCredentialExchangeRecord, exchangeRecordId],
-    ])
+    expect(harness.calls).toEqual([{ repo: 'credentialExchange', op: 'delete', id: 'cred-exchange-1' }])
+    expectNoProtocolCredentialDeletes(harness)
   })
 
-  test('proof exchange: deletes via StorageService with the proof record class', async () => {
+  test('credential and proof exchanges go through their repositories, which emit lifecycle events', async () => {
+    // Repository.deleteById is storageService.deleteById plus a RecordDeleted emit — no extra read
+    // and no cascade — so it keeps the safety property while preserving the event every other Credo
+    // delete path produces.
     const harness = makeHarness()
 
-    await deletePurgeRecord(harness.agent, PurgeRecordType.DIDCOMM_PROOF, 'proof-1')
+    await deletePurgeRecord(harness.agent as never, PurgeRecordType.DIDCOMM_CREDENTIAL, 'cred-1')
+    await deletePurgeRecord(harness.agent as never, PurgeRecordType.DIDCOMM_PROOF, 'proof-1')
 
-    expect(harness.storageService.deleteById).toHaveBeenCalledWith(AGENT_CONTEXT, DidCommProofExchangeRecord, 'proof-1')
-    expectNoProtocolDeletes(harness)
+    expect(harness.repos.credentials.deleteById).toHaveBeenCalledWith(AGENT_CONTEXT, 'cred-1')
+    expect(harness.repos.proofs.deleteById).toHaveBeenCalledWith(AGENT_CONTEXT, 'proof-1')
+    expectNoProtocolCredentialDeletes(harness)
   })
 
-  test('OOB: deletes via StorageService with the OOB record class', async () => {
+  test('OOB uses its API so mediator routing is cleaned up, not the repository', async () => {
+    // DidCommOutOfBandApi.deleteById deregisters the invitation's recipient keys from the mediator
+    // when the record has a mediatorId, carries only inline services, and has no related connection.
+    // The 7-day await-response track is exactly that case, and create-request-oob routes through
+    // mediationRecipient.getRouting() — so a raw delete would leak keylist entries at the mediator
+    // for every purged invitation. Unlike the credential API, this one cascades nothing else.
     const harness = makeHarness()
 
-    await deletePurgeRecord(harness.agent, PurgeRecordType.DIDCOMM_OOB, 'oob-1')
+    await deletePurgeRecord(harness.agent as never, PurgeRecordType.DIDCOMM_OOB, 'oob-1')
 
-    expect(harness.storageService.deleteById).toHaveBeenCalledWith(AGENT_CONTEXT, DidCommOutOfBandRecord, 'oob-1')
-    expectNoProtocolDeletes(harness)
+    expect(harness.oobDeleteById).toHaveBeenCalledWith('oob-1')
+    expect(harness.calls).toEqual([])
   })
 
-  test('OID4VC issuance/verification: stay on their repositories, which are already parent-only', async () => {
+  test('OID4VC issuance/verification stay on their repositories', async () => {
     const harness = makeHarness()
 
-    await deletePurgeRecord(harness.agent, PurgeRecordType.OID4VC_ISSUANCE, 'issuance-1')
-    await deletePurgeRecord(harness.agent, PurgeRecordType.OID4VC_VERIFICATION, 'verification-1')
+    await deletePurgeRecord(harness.agent as never, PurgeRecordType.OID4VC_ISSUANCE, 'issuance-1')
+    await deletePurgeRecord(harness.agent as never, PurgeRecordType.OID4VC_VERIFICATION, 'verification-1')
 
-    expect(harness.repositories.issuanceDeleteById).toHaveBeenCalledWith(AGENT_CONTEXT, 'issuance-1')
-    expect(harness.repositories.verificationDeleteById).toHaveBeenCalledWith(AGENT_CONTEXT, 'verification-1')
-    expect(harness.storageService.deleteById).not.toHaveBeenCalled()
+    expect(harness.repos.issuance.deleteById).toHaveBeenCalledWith(AGENT_CONTEXT, 'issuance-1')
+    expect(harness.repos.verification.deleteById).toHaveBeenCalledWith(AGENT_CONTEXT, 'verification-1')
   })
 
   test('propagates RecordNotFoundError so callers can treat "already gone" as idempotent success', async () => {
     const harness = makeHarness()
-    harness.storageService.deleteById.mockImplementation(async () => {
-      throw new RecordNotFoundError('gone', { recordType: 'CredentialRecord' })
-    })
+    harness.deleteErrors['cred-1'] = new RecordNotFoundError('gone', { recordType: 'CredentialRecord' })
 
-    await expect(deletePurgeRecord(harness.agent, PurgeRecordType.DIDCOMM_CREDENTIAL, 'cred-1')).rejects.toBeInstanceOf(
-      RecordNotFoundError,
-    )
+    await expect(
+      deletePurgeRecord(harness.agent as never, PurgeRecordType.DIDCOMM_CREDENTIAL, 'cred-1'),
+    ).rejects.toBeInstanceOf(RecordNotFoundError)
+  })
+})
+
+describe('findPurgeRecordById — re-read before deleting', () => {
+  test('reads through the same repository / API used for deletion', async () => {
+    const harness = makeHarness()
+
+    await findPurgeRecordById(harness.agent as never, PurgeRecordType.DIDCOMM_PROOF, 'proof-1')
+    await findPurgeRecordById(harness.agent as never, PurgeRecordType.DIDCOMM_OOB, 'oob-1')
+
+    expect(harness.repos.proofs.findById).toHaveBeenCalledWith(AGENT_CONTEXT, 'proof-1')
+    expect(harness.oobFindById).toHaveBeenCalledWith('oob-1')
   })
 })
 
@@ -227,8 +195,7 @@ describe('DidCommMessageRecord cascade', () => {
   test('only credential and proof exchanges own message children', () => {
     expect(RECORD_TYPES_WITH_DIDCOMM_MESSAGE_CHILDREN.has(PurgeRecordType.DIDCOMM_CREDENTIAL)).toBe(true)
     expect(RECORD_TYPES_WITH_DIDCOMM_MESSAGE_CHILDREN.has(PurgeRecordType.DIDCOMM_PROOF)).toBe(true)
-    // OOB carries its invitation inline; the OID4VC sessions are not DIDComm at all. Querying for
-    // children there would be a wasted round-trip per record on the largest category.
+    // OOB carries its invitation inline; the OID4VC sessions are not DIDComm at all.
     expect(RECORD_TYPES_WITH_DIDCOMM_MESSAGE_CHILDREN.has(PurgeRecordType.DIDCOMM_OOB)).toBe(false)
     expect(RECORD_TYPES_WITH_DIDCOMM_MESSAGE_CHILDREN.has(PurgeRecordType.OID4VC_ISSUANCE)).toBe(false)
     expect(RECORD_TYPES_WITH_DIDCOMM_MESSAGE_CHILDREN.has(PurgeRecordType.OID4VC_VERIFICATION)).toBe(false)
@@ -237,22 +204,40 @@ describe('DidCommMessageRecord cascade', () => {
   test('children are looked up by the associatedRecordId tag', async () => {
     const harness = makeHarness([{ id: 'msg-1' }, { id: 'msg-2' }])
 
-    const childIds = await findDidCommMessageChildIds(harness.agent, 'cred-exchange-1')
+    const childIds = await findDidCommMessageChildIds(harness.agent as never, 'cred-exchange-1')
 
-    expect(harness.storageService.findByQuery).toHaveBeenCalledWith(AGENT_CONTEXT, DidCommMessageRecord, {
+    expect(harness.repos.didcommMessages.findByQuery).toHaveBeenCalledWith(AGENT_CONTEXT, {
       associatedRecordId: 'cred-exchange-1',
     })
     expect(childIds).toEqual(['msg-1', 'msg-2'])
   })
 
-  test('children are deleted as DidCommMessageRecords', async () => {
+  test('children are deleted through the message repository', async () => {
     const harness = makeHarness()
 
-    await deleteDidCommMessageChildren(harness.agent, ['msg-1', 'msg-2'])
+    const removed = await deleteDidCommMessageChildren(harness.agent as never, ['msg-1', 'msg-2'])
 
-    expect(harness.storageService.deleteById.mock.calls).toEqual([
-      [AGENT_CONTEXT, DidCommMessageRecord, 'msg-1'],
-      [AGENT_CONTEXT, DidCommMessageRecord, 'msg-2'],
+    expect(removed).toBe(2)
+    expect(harness.calls).toEqual([
+      { repo: 'didcommMessage', op: 'delete', id: 'msg-1' },
+      { repo: 'didcommMessage', op: 'delete', id: 'msg-2' },
     ])
+  })
+
+  test('an already-gone child is counted as removed and does not abort the cascade', async () => {
+    const harness = makeHarness()
+    harness.deleteErrors['msg-1'] = new RecordNotFoundError('gone', { recordType: 'DidCommMessageRecord' })
+
+    const removed = await deleteDidCommMessageChildren(harness.agent as never, ['msg-1', 'msg-2'])
+
+    expect(removed).toBe(2)
+    expect(harness.calls).toEqual([{ repo: 'didcommMessage', op: 'delete', id: 'msg-2' }])
+  })
+
+  test('a real child failure propagates so the parent is left in place', async () => {
+    const harness = makeHarness()
+    harness.deleteErrors['msg-1'] = new Error('storage locked')
+
+    await expect(deleteDidCommMessageChildren(harness.agent as never, ['msg-1'])).rejects.toThrow('storage locked')
   })
 })

--- a/src/purge/__tests__/PurgeDeleteRecord.spec.ts
+++ b/src/purge/__tests__/PurgeDeleteRecord.spec.ts
@@ -13,7 +13,7 @@
  */
 import { jest } from '@jest/globals'
 
-const { InjectionSymbols, RecordNotFoundError } = await import('@credo-ts/core')
+const { InjectionSymbols, RecordNotFoundError, W3cCredentialRepository } = await import('@credo-ts/core')
 const { DidCommCredentialExchangeRecord, DidCommMessageRecord, DidCommOutOfBandRecord, DidCommProofExchangeRecord } =
   await import('@credo-ts/didcomm')
 const { OpenId4VcIssuanceSessionRepository, OpenId4VcVerificationSessionRepository } =
@@ -54,7 +54,12 @@ interface Harness {
     issuanceDeleteById: jest.Mock<any>
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     verificationDeleteById: jest.Mock<any>
+    /** The holder's stored JSON-LD credential. Must never be reached. */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    w3cDelete: jest.Mock<any>
   }
+  /** Tokens the code under test asked the container for. */
+  resolved: unknown[]
 }
 
 function makeHarness(messages: Array<{ id: string }> = []): Harness {
@@ -70,16 +75,20 @@ function makeHarness(messages: Array<{ id: string }> = []): Harness {
   const repositories = {
     issuanceDeleteById: jest.fn(async () => {}),
     verificationDeleteById: jest.fn(async () => {}),
+    w3cDelete: jest.fn(async () => {}),
   }
+  const resolved: unknown[] = []
 
   const agent = {
     context: AGENT_CONTEXT,
     dependencyManager: {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       resolve: (token: any) => {
+        resolved.push(token)
         if (token === InjectionSymbols.StorageService) return storageService
         if (token === OpenId4VcIssuanceSessionRepository) return { deleteById: repositories.issuanceDeleteById }
         if (token === OpenId4VcVerificationSessionRepository) return { deleteById: repositories.verificationDeleteById }
+        if (token === W3cCredentialRepository) return { delete: repositories.w3cDelete, findById: jest.fn() }
         throw new Error(`unexpected token: ${String(token)}`)
       },
     },
@@ -92,7 +101,7 @@ function makeHarness(messages: Array<{ id: string }> = []): Harness {
     },
   }
 
-  return { agent, storageService, protocolApis, repositories }
+  return { agent, storageService, protocolApis, repositories, resolved }
 }
 
 function expectNoProtocolDeletes(harness: Harness) {
@@ -138,6 +147,39 @@ describe('deletePurgeRecord — storage-level deletes only (§4.1)', () => {
       expect((recordClass as any).type).toBe('CredentialRecord')
     }
     expectNoProtocolDeletes(harness)
+  })
+
+  test('JSON-LD over DIDComm: the holder\u2019s stored W3cCredentialRecord is never reached', async () => {
+    // This is the exact production stack (JSON-LD credentials over DIDComm, holder cloud wallet) and
+    // the exact chain the old protocol delete followed:
+    //
+    //   credentials.deleteById(id)
+    //     -> DidCommCredentialV2Protocol.delete()            deleteAssociatedCredentials ?? true
+    //     -> getFormatServiceForRecordType('w3c')            FIRST format service claiming 'w3c',
+    //                                                        which in cliAgent.ts is legacyIndy,
+    //                                                        NOT the JSON-LD service
+    //     -> AnonCredsRsHolderService.deleteCredential(id)
+    //     -> W3cCredentialRepository.findById(id) hits       the binding IS a W3cCredentialRecord id
+    //     -> W3cCredentialRepository.delete(...)             holder's credential destroyed
+    //
+    // Note the JSON-LD format service's own deleteCredentialById() throws 'Not implemented', so it
+    // would have been harmless — but it never runs, because legacyIndy is registered first and also
+    // declares credentialRecordType 'w3c'. There was no accidental protection.
+    const harness = makeHarness()
+    // The binding the exchange record would carry for an issued JSON-LD credential.
+    const exchangeRecordId = 'cred-exchange-1'
+
+    await deletePurgeRecord(harness.agent, PurgeRecordType.DIDCOMM_CREDENTIAL, exchangeRecordId)
+
+    // The stored credential's repository is never even asked for, let alone called.
+    expect(harness.resolved).not.toContain(W3cCredentialRepository)
+    expect(harness.repositories.w3cDelete).not.toHaveBeenCalled()
+    // And the protocol entry point that starts the chain is never invoked.
+    expectNoProtocolDeletes(harness)
+    // Exactly one delete, naming the exchange record class.
+    expect(harness.storageService.deleteById.mock.calls).toEqual([
+      [AGENT_CONTEXT, DidCommCredentialExchangeRecord, exchangeRecordId],
+    ])
   })
 
   test('proof exchange: deletes via StorageService with the proof record class', async () => {

--- a/src/purge/__tests__/PurgeEngine.spec.ts
+++ b/src/purge/__tests__/PurgeEngine.spec.ts
@@ -77,21 +77,47 @@ function makeAgent(options: AgentOptions = {}) {
   const deletedIds: string[] = []
   const queriedStates: Record<string, string[]> = { credentials: [], proofs: [], oob: [] }
 
+  // A mutable in-memory store. The engine pages with {limit, offset} and advances the offset only
+  // past records it did NOT remove, so the mock must actually remove them — otherwise a paging bug
+  // (or an offset that fails to advance) would loop forever here instead of being caught.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const store: Record<string, any[]> = {}
+  for (const [state, records] of Object.entries(recordsByState)) store[state] = [...records]
+  const childStore: Record<string, Array<{ id: string }>> = {}
+  for (const [parentId, msgs] of Object.entries(children)) childStore[parentId] = [...msgs]
+
+  const removeById = (id: string) => {
+    for (const records of Object.values(store)) {
+      const index = records.findIndex((record) => record.id === id)
+      if (index >= 0) return void records.splice(index, 1)
+    }
+    for (const msgs of Object.values(childStore)) {
+      const index = msgs.findIndex((msg) => msg.id === id)
+      if (index >= 0) return void msgs.splice(index, 1)
+    }
+  }
+
   const storageService = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    findByQuery: jest.fn(async (_ctx: any, _recordClass: any, query: any) => children[query.associatedRecordId] ?? []),
+    findByQuery: jest.fn(
+      async (_ctx: any, _recordClass: any, query: any) => childStore[query.associatedRecordId] ?? [],
+    ),
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     deleteById: jest.fn(async (_ctx: any, _recordClass: any, id: string) => {
       const error = deleteErrors[id]
       if (error) throw error
       deletedIds.push(id)
+      removeById(id)
     }),
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const scanFor = (bucket: string) => async (query: any) => {
+  const scanFor = (bucket: string) => async (query: any, queryOptions?: { limit?: number; offset?: number }) => {
     queriedStates[bucket].push(query.state)
-    return recordsByState[query.state] ?? []
+    const all = store[query.state] ?? []
+    const offset = queryOptions?.offset ?? 0
+    const limit = queryOptions?.limit ?? all.length
+    return all.slice(offset, offset + limit)
   }
 
   const agent = {
@@ -452,9 +478,49 @@ describe('purgeTenant — modes and guards', () => {
     expect(scanCount).toBe(1)
     expect(deletedIds).toEqual(['cred-1'])
     expect(logger.warn).toHaveBeenCalledWith(
-      '[Purge] Time budget exhausted — tenant will resume on the next run',
-      expect.objectContaining({ timeBudgetMs: 10 }),
+      '[Purge] Time budget exhausted — remaining work continues on subsequent runs',
+      expect.objectContaining({ timeBudgetMs: 10, stoppedAt: PurgeRecordType.DIDCOMM_CREDENTIAL }),
     )
+  })
+
+  test('the time budget is per tenant, so a truncated tenant does not starve the next one', async () => {
+    const config = makeConfig({ timeBudgetMs: 10 })
+
+    // Tenant A burns its whole budget on a slow scan and truncates.
+    const a = makeAgent()
+    a.agent.modules.didcomm.credentials.findAllByQuery = jest.fn(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20))
+      return [{ id: 'a-1', updatedAt: daysAgo(60) }]
+    }) as never
+    const resultA = await purgeTenant(a.agent as never, 'tenant-a', config, 'run-1')
+    expect(resultA.truncated).toBe(true)
+
+    // Tenant B, processed after it in the same run, still gets a full allowance and does its work.
+    const b = makeAgent({ recordsByState: { done: [{ id: 'b-1', updatedAt: daysAgo(60) }] } })
+    const resultB = await purgeTenant(b.agent as never, 'tenant-b', config, 'run-1')
+
+    expect(resultB.truncated).toBe(false)
+    expect(b.deletedIds).toEqual(['b-1'])
+  })
+
+  test('record-type order rotates so a truncated tenant cannot starve the trailing types', () => {
+    const config = makeConfig({
+      recordTypes: [PurgeRecordType.DIDCOMM_CREDENTIAL, PurgeRecordType.DIDCOMM_PROOF, PurgeRecordType.DIDCOMM_OOB],
+    })
+
+    const order = async (rotation: number) => {
+      const { agent } = makeAgent()
+      const result = await purgeTenant(agent as never, 't', config, 'run', undefined, rotation)
+      return result.categories.map((category) => category.recordType)
+    }
+
+    // Without rotation, a budget that only covers the first type would mean OOB — the largest
+    // category in production — never runs on any tick.
+    return Promise.all([order(0), order(1), order(2)]).then(([first, second, third]) => {
+      expect(first[0]).toBe(PurgeRecordType.DIDCOMM_CREDENTIAL)
+      expect(second[0]).toBe(PurgeRecordType.DIDCOMM_PROOF)
+      expect(third[0]).toBe(PurgeRecordType.DIDCOMM_OOB)
+    })
   })
 
   test('scans are state-scoped — findAllByQuery is never called with an empty query', async () => {
@@ -478,15 +544,55 @@ describe('purgeTenant — modes and guards', () => {
     }
   })
 
-  test('processes eligible records in batches of batchSize', async () => {
+  test('never holds more than one page in memory, however large the state set', async () => {
+    // The regression this guards: the scan used to fetch the entire state-scoped result set in one
+    // call. On an undrained wallet state=request-sent alone was the clear majority of all proof
+    // exchanges, and materialising those decrypted into the heap means an OOM or GC pauses that hit
+    // live traffic. Nothing forces the backfill to run first, so the scan itself must be bounded.
+    const total = 1_000
+    const records = Array.from({ length: total }, (_, index) => ({ id: `cred-${index}`, updatedAt: daysAgo(60) }))
+    const { agent, deletedIds } = makeAgent({ recordsByState: { done: records } })
+
+    let largestPage = 0
+    const inner = agent.modules.didcomm.credentials.findAllByQuery
+    agent.modules.didcomm.credentials.findAllByQuery = jest.fn(async (query, queryOptions) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const page = await (inner as any)(query, queryOptions)
+      largestPage = Math.max(largestPage, page.length)
+      return page
+    }) as never
+
+    const result = await purgeTenant(agent as never, 'tenant-abc', makeConfig({ batchSize: 50 }), 'run-1')
+
+    // Every record is drained, but never more than one page is resident at a time.
+    expect(deletedIds).toHaveLength(total)
+    expect(result.parentsDeleted).toBe(total)
+    expect(largestPage).toBe(50)
+  })
+
+  test('a page of records that are all too recent advances the offset instead of looping', async () => {
+    // Nothing is removed from such a page, so the offset must advance by the full page or the drain
+    // would re-read the same page forever.
+    const recent = Array.from({ length: 5 }, (_, index) => ({ id: `fresh-${index}`, updatedAt: daysAgo(1) }))
+    const { agent, deletedIds, logger } = makeAgent({ recordsByState: { done: [...recent] } })
+
+    const result = await purgeTenant(agent as never, 'tenant-abc', makeConfig({ batchSize: 2 }), 'run-1')
+
+    expect(deletedIds).toEqual([])
+    expect(result.eligible).toBe(0)
+    // 5 records at page size 2 → 3 pages, then the short page ends it. No infinite loop.
+    expect(logger.debug.mock.calls.filter((call) => call[0] === '[Purge] Page complete')).toHaveLength(3)
+  })
+
+  test('pages the scan by batchSize instead of loading the whole state set', async () => {
     const records = Array.from({ length: 5 }, (_, index) => ({ id: `cred-${index}`, updatedAt: daysAgo(60) }))
     const { agent, deletedIds, logger } = makeAgent({ recordsByState: { done: records } })
 
     await purgeTenant(agent as never, 'tenant-abc', makeConfig({ batchSize: 2 }), 'run-1')
 
     expect(deletedIds).toHaveLength(5)
-    const batchLogs = logger.debug.mock.calls.filter((call) => call[0] === '[Purge] Batch complete')
-    // 5 records at batchSize 2 → 3 batches.
-    expect(batchLogs).toHaveLength(3)
+    const pageLogs = logger.debug.mock.calls.filter((call) => call[0] === '[Purge] Page complete')
+    // 5 records at page size 2 → pages of 2, 2, 1; the short final page ends the drain.
+    expect(pageLogs).toHaveLength(3)
   })
 })

--- a/src/purge/__tests__/PurgeEngine.spec.ts
+++ b/src/purge/__tests__/PurgeEngine.spec.ts
@@ -44,8 +44,9 @@ function makeConfig(overrides: Partial<PurgeCronConfig> = {}): PurgeCronConfig {
     // 0 keeps the tests fast; the throttle path itself is asserted separately via batchSize.
     throttleMs: 0,
     timeBudgetMs: 0,
-    staleProofEnabled: false,
-    staleProofTtlSeconds: 90 * 24 * 60 * 60,
+    staleProofEnabled: true,
+    abandonedTtlSeconds: 7 * 24 * 60 * 60,
+    allowShortAbandonedTtl: false,
     ...overrides,
   }
 }
@@ -134,7 +135,7 @@ describe('buildScanPlans — retention policy', () => {
     ])
   })
 
-  test('no credential plan exists for any non-terminal state, even with stale-proof purging enabled', () => {
+  test('no credential plan exists for any non-terminal state, even with abandoned purging enabled', () => {
     // The stale policy is proof-only by construction. A holder can still accept a pending offer
     // (`offer-received`) after any TTL, so deleting the issuer-side record is unrecoverable.
     const plans = buildScanPlans(PurgeRecordType.DIDCOMM_CREDENTIAL, makeConfig({ staleProofEnabled: true }))
@@ -146,29 +147,56 @@ describe('buildScanPlans — retention policy', () => {
     }
   })
 
-  test('proof plans cover terminal states only until stale purging is opted into', () => {
-    const off = buildScanPlans(PurgeRecordType.DIDCOMM_PROOF, makeConfig()).map((plan) => plan.query.state)
-    expect(off).toEqual([DidCommProofState.Done, DidCommProofState.Abandoned, DidCommProofState.Declined])
-
-    const on = buildScanPlans(PurgeRecordType.DIDCOMM_PROOF, makeConfig({ staleProofEnabled: true }))
+  test('non-terminal proof states are swept by default and can be turned off', () => {
+    // request-sent was ~68% of all proof exchanges in the July 2026 production drain, so sweeping
+    // it is the default, not an opt-in.
+    const on = buildScanPlans(PurgeRecordType.DIDCOMM_PROOF, makeConfig()).map((plan) => plan.query.state)
     for (const nonTerminal of DIDCOMM_PROOF_NON_TERMINAL_STATES) {
-      expect(on.map((plan) => plan.query.state)).toContain(nonTerminal)
+      expect(on).toContain(nonTerminal)
     }
+
+    const off = buildScanPlans(PurgeRecordType.DIDCOMM_PROOF, makeConfig({ staleProofEnabled: false }))
+    expect(off.map((plan) => plan.query.state)).toEqual([
+      DidCommProofState.Done,
+      DidCommProofState.Abandoned,
+      DidCommProofState.Declined,
+    ])
   })
 
-  test('stale proof plans use the separate, longer TTL', () => {
-    const config = makeConfig({
-      staleProofEnabled: true,
-      ttlSeconds: 30 * 24 * 60 * 60,
-      staleProofTtlSeconds: 90 * 24 * 60 * 60,
-    })
+  test('abandoned records use a SHORTER cutoff than completed ones', () => {
+    const config = makeConfig({ ttlSeconds: 30 * 24 * 60 * 60, abandonedTtlSeconds: 7 * 24 * 60 * 60 })
     const plans = buildScanPlans(PurgeRecordType.DIDCOMM_PROOF, config)
 
-    const terminalPlan = plans.find((plan) => plan.query.state === DidCommProofState.Done)
-    const stalePlan = plans.find((plan) => plan.query.state === DidCommProofState.RequestSent)
+    const completed = plans.find((plan) => plan.query.state === DidCommProofState.Done)
+    const abandoned = plans.find((plan) => plan.query.state === DidCommProofState.RequestSent)
 
-    // The stale cutoff must be further in the past — i.e. a stricter age requirement.
-    expect(stalePlan!.cutoff.getTime()).toBeLessThan(terminalPlan!.cutoff.getTime())
+    // A dead request has no value; a completed exchange is an audit record. So the abandoned cutoff
+    // is NEARER to now — records qualify sooner — which is the opposite of the original assumption.
+    expect(abandoned!.cutoff.getTime()).toBeGreaterThan(completed!.cutoff.getTime())
+  })
+
+  test('the non-reusable await-response OOB track uses the abandoned TTL, the done track does not', () => {
+    // OOB was the largest purgeable category in production (7.78M, 91% eligible), and
+    // create-request-oob mints one per connectionless proof request — the other half of request-sent.
+    const config = makeConfig({ ttlSeconds: 30 * 24 * 60 * 60, abandonedTtlSeconds: 7 * 24 * 60 * 60 })
+    const [done, awaitResponse] = buildScanPlans(PurgeRecordType.DIDCOMM_OOB, config)
+
+    expect(awaitResponse.cutoff.getTime()).toBeGreaterThan(done.cutoff.getTime())
+  })
+
+  test('OID4VC issuance sessions carrying revocation info are retained indefinitely', () => {
+    // revokeBySessionId reads issuanceMetadata.StatusListInfo off this record to get
+    // {listId, index, issuerDid}. There is no other copy, so purging it would make the credential
+    // permanently unrevocable.
+    const [plan] = buildScanPlans(PurgeRecordType.OID4VC_ISSUANCE, makeConfig())
+
+    expect(plan.retain!({ id: 'a', issuanceMetadata: { StatusListInfo: [{ listId: 'l', index: 1 }] } })).toBe(true)
+    // Defensive: an unexpected non-array shape still reads as "might be revocable".
+    expect(plan.retain!({ id: 'b', issuanceMetadata: { StatusListInfo: { listId: 'l' } } })).toBe(true)
+    // Nothing to revoke — these still age out.
+    expect(plan.retain!({ id: 'c', issuanceMetadata: { StatusListInfo: [] } })).toBe(false)
+    expect(plan.retain!({ id: 'd', issuanceMetadata: {} })).toBe(false)
+    expect(plan.retain!({ id: 'e' })).toBe(false)
   })
 
   test('OOB has a done track and a non-reusable-only await-response track', () => {

--- a/src/purge/__tests__/PurgeEngine.spec.ts
+++ b/src/purge/__tests__/PurgeEngine.spec.ts
@@ -309,6 +309,27 @@ describe('purgeTenant — DidCommMessageRecord cascade', () => {
     expect(result.parentsDeleted).toBe(1)
   })
 
+  test('an already-gone child does not abort the cascade or block the parent', async () => {
+    // Regression: RecordNotFoundError from a CHILD used to escape the cascade and be handled as
+    // "parent already absent" — so the parent survived while being reported as successfully
+    // deleted. On a wallet with a partially-completed previous run that made every run stall at
+    // partial progress while the summary looked clean.
+    const { agent, deletedIds } = makeAgent({
+      recordsByState: { done: [{ id: 'cred-1', updatedAt: daysAgo(60) }] },
+      children: { 'cred-1': [{ id: 'msg-gone' }, { id: 'msg-live' }] },
+      deleteErrors: { 'msg-gone': new RecordNotFoundError('gone', { recordType: 'DidCommMessageRecord' }) },
+    })
+
+    const result = await purgeTenant(agent as never, 'tenant-abc', makeConfig(), 'run-1')
+
+    // The surviving child and the parent are both removed; absence of the first is not an error.
+    expect(deletedIds).toEqual(['msg-live', 'cred-1'])
+    expect(result.parentsDeleted).toBe(1)
+    expect(result.childrenDeleted).toBe(2) // one deleted here, one already gone
+    expect(result.categories[0].alreadyAbsent).toBe(0)
+    expect(result.failed).toBe(0)
+  })
+
   test('leaves the parent in place when a child delete fails, so no orphan is created', async () => {
     const { agent, deletedIds } = makeAgent({
       recordsByState: {

--- a/src/purge/__tests__/PurgeEngine.spec.ts
+++ b/src/purge/__tests__/PurgeEngine.spec.ts
@@ -17,8 +17,10 @@
  */
 import { jest } from '@jest/globals'
 
-const { InjectionSymbols, RecordNotFoundError } = await import('@credo-ts/core')
+const { RecordNotFoundError } = await import('@credo-ts/core')
 const { DidCommCredentialState, DidCommProofState } = await import('@credo-ts/didcomm')
+const { DidCommCredentialExchangeRepository, DidCommMessageRepository, DidCommProofExchangeRepository } =
+  await import('@credo-ts/didcomm')
 const { OpenId4VcIssuanceSessionRepository, OpenId4VcVerificationSessionRepository } =
   await import('@credo-ts/openid4vc')
 const { buildScanPlans, purgeTenant } = await import('../PurgeEngine')
@@ -82,7 +84,11 @@ function makeAgent(options: AgentOptions = {}) {
   // (or an offset that fails to advance) would loop forever here instead of being caught.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const store: Record<string, any[]> = {}
-  for (const [state, records] of Object.entries(recordsByState)) store[state] = [...records]
+  // Stamp `state` from the key. Real records carry it, and the engine re-reads each record and
+  // re-checks its state immediately before deleting, so the fixtures must carry it too.
+  for (const [state, records] of Object.entries(recordsByState)) {
+    store[state] = records.map((record) => ({ state, ...record }))
+  }
   const childStore: Record<string, Array<{ id: string }>> = {}
   for (const [parentId, msgs] of Object.entries(children)) childStore[parentId] = [...msgs]
 
@@ -97,18 +103,48 @@ function makeAgent(options: AgentOptions = {}) {
     }
   }
 
-  const storageService = {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    findByQuery: jest.fn(
-      async (_ctx: any, _recordClass: any, query: any) => childStore[query.associatedRecordId] ?? [],
-    ),
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    deleteById: jest.fn(async (_ctx: any, _recordClass: any, id: string) => {
+  // Repository-shaped mocks over the mutable store. `deleteById` removes, `findById` re-reads —
+  // the engine re-reads every record immediately before deleting it, so the mock has to reflect
+  // live mutations for the state-change tests to mean anything.
+  const findRecord = (id: string) => {
+    for (const records of Object.values(store)) {
+      const found = records.find((record) => record.id === id)
+      if (found) return found
+    }
+    return null
+  }
+
+  const exchangeRepo = () => ({
+    deleteById: jest.fn(async (_ctx: unknown, id: string) => {
       const error = deleteErrors[id]
       if (error) throw error
       deletedIds.push(id)
       removeById(id)
     }),
+    findById: jest.fn(async (_ctx: unknown, id: string) => findRecord(id)),
+  })
+  const credentialRepo = exchangeRepo()
+  const proofRepo = exchangeRepo()
+
+  const messageRepo = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    findByQuery: jest.fn(async (_ctx: unknown, query: any) => childStore[query.associatedRecordId] ?? []),
+    deleteById: jest.fn(async (_ctx: unknown, id: string) => {
+      const error = deleteErrors[id]
+      if (error) throw error
+      deletedIds.push(id)
+      removeById(id)
+    }),
+  }
+
+  const oobApi = {
+    deleteById: jest.fn(async (id: string) => {
+      const error = deleteErrors[id]
+      if (error) throw error
+      deletedIds.push(id)
+      removeById(id)
+    }),
+    findById: jest.fn(async (id: string) => findRecord(id)),
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -126,9 +162,15 @@ function makeAgent(options: AgentOptions = {}) {
     dependencyManager: {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       resolve: (token: any) => {
-        if (token === InjectionSymbols.StorageService) return storageService
+        if (token === DidCommCredentialExchangeRepository) return credentialRepo
+        if (token === DidCommProofExchangeRepository) return proofRepo
+        if (token === DidCommMessageRepository) return messageRepo
         if (token === OpenId4VcIssuanceSessionRepository || token === OpenId4VcVerificationSessionRepository) {
-          return { findByQuery: jest.fn(async () => []), deleteById: jest.fn(async () => {}) }
+          return {
+            findByQuery: jest.fn(async () => []),
+            deleteById: jest.fn(async () => {}),
+            findById: jest.fn(async () => null),
+          }
         }
         throw new Error(`unexpected token: ${String(token)}`)
       },
@@ -137,12 +179,12 @@ function makeAgent(options: AgentOptions = {}) {
       didcomm: {
         credentials: { findAllByQuery: jest.fn(scanFor('credentials')) },
         proofs: { findAllByQuery: jest.fn(scanFor('proofs')) },
-        oob: { findAllByQuery: jest.fn(scanFor('oob')) },
+        oob: Object.assign(oobApi, { findAllByQuery: jest.fn(scanFor('oob')) }),
       },
     },
   }
 
-  return { agent, logger, storageService, deletedIds, queriedStates }
+  return { agent, logger, store, deletedIds, queriedStates }
 }
 
 // ---------------------------------------------------------------------------
@@ -335,6 +377,66 @@ describe('purgeTenant — DidCommMessageRecord cascade', () => {
     expect(result.parentsDeleted).toBe(1)
   })
 
+  test('a record that changes state between scan and delete is left alone', async () => {
+    // Requested in review. The page is a snapshot and records are processed sequentially behind a
+    // throttle, so a holder can answer a long-abandoned proof request while it waits its turn.
+    // Deleting on the stale snapshot would take out a flow that had just become live again.
+    const { agent, deletedIds, logger, store } = makeAgent({
+      recordsByState: {
+        'request-sent': [
+          { id: 'answered', updatedAt: daysAgo(60) },
+          { id: 'still-dead', updatedAt: daysAgo(60) },
+        ],
+      },
+    })
+
+    // Simulate the holder responding after the scan but before this record's turn: the exchange
+    // advances to presentation-received and gets a fresh updatedAt.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const proofRepo = agent.dependencyManager.resolve(DidCommProofExchangeRepository) as any
+    const realFindById = proofRepo.findById
+    proofRepo.findById = jest.fn(async (ctx: unknown, id: string) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const record = await (realFindById as any)(ctx, id)
+      if (id === 'answered') return { ...record, state: 'presentation-received', updatedAt: new Date() }
+      return record
+    }) as never
+
+    const result = await purgeTenant(
+      agent as never,
+      'tenant-abc',
+      makeConfig({ recordTypes: [PurgeRecordType.DIDCOMM_PROOF] }),
+      'run-1',
+    )
+
+    // The revived exchange survives; the genuinely dead one is still purged.
+    expect(deletedIds).toEqual(['still-dead'])
+    expect(store['request-sent'].map((record) => record.id)).toEqual(['answered'])
+    const proofs = result.categories.find((category) => category.recordType === PurgeRecordType.DIDCOMM_PROOF)!
+    expect(proofs.skippedChanged).toBe(1)
+    expect(proofs.parentsDeleted).toBe(1)
+    expect(proofs.failed).toBe(0)
+    expect(logger.debug).toHaveBeenCalledWith(
+      '[Purge] Record changed since the scan — leaving it alone',
+      expect.objectContaining({ recordId: 'answered', state: 'presentation-received' }),
+    )
+  })
+
+  test('a record deleted by someone else between scan and delete counts as already absent', async () => {
+    const { agent, deletedIds } = makeAgent({
+      recordsByState: { done: [{ id: 'vanished', updatedAt: daysAgo(60) }] },
+    })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const credentialRepo = agent.dependencyManager.resolve(DidCommCredentialExchangeRepository) as any
+    credentialRepo.findById = jest.fn(async () => null) as never
+
+    const result = await purgeTenant(agent as never, 'tenant-abc', makeConfig(), 'run-1')
+
+    expect(deletedIds).toEqual([])
+    expect(result.categories[0].alreadyAbsent).toBe(1)
+    expect(result.failed).toBe(0)
+  })
+
   test('an already-gone child does not abort the cascade or block the parent', async () => {
     // Regression: RecordNotFoundError from a CHILD used to escape the cascade and be handled as
     // "parent already absent" — so the parent survived while being reported as successfully
@@ -383,14 +485,13 @@ describe('purgeTenant — DidCommMessageRecord cascade', () => {
 
 describe('purgeTenant — modes and guards', () => {
   test('dry-run deletes nothing but still reports the census', async () => {
-    const { agent, deletedIds, storageService } = makeAgent({
+    const { agent, deletedIds } = makeAgent({
       recordsByState: { done: [{ id: 'cred-1', updatedAt: daysAgo(60) }] },
       children: { 'cred-1': [{ id: 'msg-1' }, { id: 'msg-2' }] },
     })
 
     const result = await purgeTenant(agent as never, 'tenant-abc', makeConfig({ dryRun: true }), 'run-1')
 
-    expect(storageService.deleteById).not.toHaveBeenCalled()
     expect(deletedIds).toEqual([])
     // Counts mirror what a live run would remove, so a dry-run census is directly comparable.
     expect(result.eligible).toBe(1)
@@ -459,15 +560,19 @@ describe('purgeTenant — modes and guards', () => {
   })
 
   test('the per-tenant time budget truncates the run instead of overrunning', async () => {
-    const { agent, logger, deletedIds } = makeAgent()
+    const { agent, logger, deletedIds } = makeAgent({
+      recordsByState: { done: [{ id: 'cred-1', updatedAt: daysAgo(60) }] },
+    })
 
-    // The budget is checked at plan and batch boundaries, so make the first scan outlast it: the
-    // credential category has three state plans, and the second one must find the budget spent.
+    // The budget is checked on plan entry and between pages, so make the first scan outlast it: the
+    // credential category has three state plans, and the second must find the budget already spent.
     let scanCount = 0
-    agent.modules.didcomm.credentials.findAllByQuery = jest.fn(async () => {
+    const inner = agent.modules.didcomm.credentials.findAllByQuery
+    agent.modules.didcomm.credentials.findAllByQuery = jest.fn(async (query, queryOptions) => {
       scanCount++
       await new Promise((resolve) => setTimeout(resolve, 20))
-      return [{ id: `cred-${scanCount}`, updatedAt: daysAgo(60) }]
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (inner as any)(query, queryOptions)
     }) as never
 
     const result = await purgeTenant(agent as never, 'tenant-abc', makeConfig({ timeBudgetMs: 10 }), 'run-1')

--- a/src/purge/__tests__/PurgeEngine.spec.ts
+++ b/src/purge/__tests__/PurgeEngine.spec.ts
@@ -1,0 +1,443 @@
+/**
+ * Tests for the steady-state purge engine (INTEGRATION-PLAN-develop.md §4.2, §4.3).
+ *
+ * What is locked in here:
+ *   - **State-awareness.** Credentials are scanned only in terminal states — there is no config that
+ *     makes the engine query a non-terminal credential state. Non-terminal *proofs* are opt-in and
+ *     use their own, longer TTL.
+ *   - **Retention.** Reusable `await-response` OOB invitations survive regardless of age.
+ *   - **TTL basis.** Eligibility is keyed on `updatedAt` (last activity), not `createdAt`.
+ *   - **Cascade ordering.** Message children go before the parent, and a failed child delete leaves
+ *     the parent in place so no orphan is created.
+ *   - **Dry-run.** Nothing is deleted, but the census still counts what would go.
+ *   - **Idempotency.** `RecordNotFoundError` counts as a success, not a failure.
+ *   - **Zero-progress guard.** A batch where every delete genuinely failed aborts the record type.
+ *
+ * Runs under Jest ESM mode (see jest.config.base.ts).
+ */
+import { jest } from '@jest/globals'
+
+const { InjectionSymbols, RecordNotFoundError } = await import('@credo-ts/core')
+const { DidCommCredentialState, DidCommProofState } = await import('@credo-ts/didcomm')
+const { OpenId4VcIssuanceSessionRepository, OpenId4VcVerificationSessionRepository } =
+  await import('@credo-ts/openid4vc')
+const { buildScanPlans, purgeTenant } = await import('../PurgeEngine')
+const { DIDCOMM_CREDENTIAL_NON_TERMINAL_STATES, DIDCOMM_PROOF_NON_TERMINAL_STATES } = await import('../PurgeStates')
+const { PurgeRecordType } = await import('../PurgeTypes')
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type PurgeCronConfig = any
+
+const DAY_MS = 86_400_000
+const TTL_SECONDS = 30 * 24 * 60 * 60 // 30 days
+
+const daysAgo = (days: number) => new Date(Date.now() - days * DAY_MS)
+
+function makeConfig(overrides: Partial<PurgeCronConfig> = {}): PurgeCronConfig {
+  return {
+    enabled: true,
+    ttlSeconds: TTL_SECONDS,
+    cronSchedule: '0 3 * * *',
+    recordTypes: [PurgeRecordType.DIDCOMM_CREDENTIAL],
+    dryRun: false,
+    batchSize: 100,
+    // 0 keeps the tests fast; the throttle path itself is asserted separately via batchSize.
+    throttleMs: 0,
+    timeBudgetMs: 0,
+    staleProofEnabled: false,
+    staleProofTtlSeconds: 90 * 24 * 60 * 60,
+    ...overrides,
+  }
+}
+
+interface AgentOptions {
+  /** Records the credential/proof/oob `findAllByQuery({ state })` returns, keyed by state. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  recordsByState?: Record<string, any[]>
+  /** `DidCommMessageRecord` children keyed by parent record id. */
+  children?: Record<string, Array<{ id: string }>>
+  /** Ids whose delete should throw the given error. */
+  deleteErrors?: Record<string, Error>
+}
+
+function makeAgent(options: AgentOptions = {}) {
+  const { recordsByState = {}, children = {}, deleteErrors = {} } = options
+
+  const logger = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    trace: jest.fn(),
+    fatal: jest.fn(),
+    test: jest.fn(),
+  }
+
+  const deletedIds: string[] = []
+  const queriedStates: Record<string, string[]> = { credentials: [], proofs: [], oob: [] }
+
+  const storageService = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    findByQuery: jest.fn(async (_ctx: any, _recordClass: any, query: any) => children[query.associatedRecordId] ?? []),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    deleteById: jest.fn(async (_ctx: any, _recordClass: any, id: string) => {
+      const error = deleteErrors[id]
+      if (error) throw error
+      deletedIds.push(id)
+    }),
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const scanFor = (bucket: string) => async (query: any) => {
+    queriedStates[bucket].push(query.state)
+    return recordsByState[query.state] ?? []
+  }
+
+  const agent = {
+    context: { contextCorrelationId: 'tenant-abc' },
+    config: { logger },
+    dependencyManager: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      resolve: (token: any) => {
+        if (token === InjectionSymbols.StorageService) return storageService
+        if (token === OpenId4VcIssuanceSessionRepository || token === OpenId4VcVerificationSessionRepository) {
+          return { findByQuery: jest.fn(async () => []), deleteById: jest.fn(async () => {}) }
+        }
+        throw new Error(`unexpected token: ${String(token)}`)
+      },
+    },
+    modules: {
+      didcomm: {
+        credentials: { findAllByQuery: jest.fn(scanFor('credentials')) },
+        proofs: { findAllByQuery: jest.fn(scanFor('proofs')) },
+        oob: { findAllByQuery: jest.fn(scanFor('oob')) },
+      },
+    },
+  }
+
+  return { agent, logger, storageService, deletedIds, queriedStates }
+}
+
+// ---------------------------------------------------------------------------
+// Retention policy
+// ---------------------------------------------------------------------------
+
+describe('buildScanPlans — retention policy', () => {
+  test('credentials are scanned only in terminal states', () => {
+    const plans = buildScanPlans(PurgeRecordType.DIDCOMM_CREDENTIAL, makeConfig())
+    const states = plans.map((plan) => plan.query.state)
+
+    expect(states).toEqual([
+      DidCommCredentialState.Done,
+      DidCommCredentialState.Abandoned,
+      DidCommCredentialState.Declined,
+    ])
+  })
+
+  test('no credential plan exists for any non-terminal state, even with stale-proof purging enabled', () => {
+    // The stale policy is proof-only by construction. A holder can still accept a pending offer
+    // (`offer-received`) after any TTL, so deleting the issuer-side record is unrecoverable.
+    const plans = buildScanPlans(PurgeRecordType.DIDCOMM_CREDENTIAL, makeConfig({ staleProofEnabled: true }))
+    const states = plans.map((plan) => plan.query.state)
+
+    expect(DIDCOMM_CREDENTIAL_NON_TERMINAL_STATES.length).toBeGreaterThan(0)
+    for (const nonTerminal of DIDCOMM_CREDENTIAL_NON_TERMINAL_STATES) {
+      expect(states).not.toContain(nonTerminal)
+    }
+  })
+
+  test('proof plans cover terminal states only until stale purging is opted into', () => {
+    const off = buildScanPlans(PurgeRecordType.DIDCOMM_PROOF, makeConfig()).map((plan) => plan.query.state)
+    expect(off).toEqual([DidCommProofState.Done, DidCommProofState.Abandoned, DidCommProofState.Declined])
+
+    const on = buildScanPlans(PurgeRecordType.DIDCOMM_PROOF, makeConfig({ staleProofEnabled: true }))
+    for (const nonTerminal of DIDCOMM_PROOF_NON_TERMINAL_STATES) {
+      expect(on.map((plan) => plan.query.state)).toContain(nonTerminal)
+    }
+  })
+
+  test('stale proof plans use the separate, longer TTL', () => {
+    const config = makeConfig({
+      staleProofEnabled: true,
+      ttlSeconds: 30 * 24 * 60 * 60,
+      staleProofTtlSeconds: 90 * 24 * 60 * 60,
+    })
+    const plans = buildScanPlans(PurgeRecordType.DIDCOMM_PROOF, config)
+
+    const terminalPlan = plans.find((plan) => plan.query.state === DidCommProofState.Done)
+    const stalePlan = plans.find((plan) => plan.query.state === DidCommProofState.RequestSent)
+
+    // The stale cutoff must be further in the past — i.e. a stricter age requirement.
+    expect(stalePlan!.cutoff.getTime()).toBeLessThan(terminalPlan!.cutoff.getTime())
+  })
+
+  test('OOB has a done track and a non-reusable-only await-response track', () => {
+    const plans = buildScanPlans(PurgeRecordType.DIDCOMM_OOB, makeConfig())
+
+    expect(plans.map((plan) => plan.query.state)).toEqual(['done', 'await-response'])
+
+    const awaitResponse = plans[1]
+    expect(awaitResponse.retain!({ id: 'a', reusable: true })).toBe(true)
+    expect(awaitResponse.retain!({ id: 'b', reusable: false })).toBe(false)
+    expect(awaitResponse.retain!({ id: 'c' })).toBe(false)
+
+    // The done track has no retain predicate — reusability is irrelevant once the flow closed.
+    expect(plans[0].retain).toBeUndefined()
+  })
+
+  test('OID4VC sessions are scanned only in terminal states', () => {
+    expect(buildScanPlans(PurgeRecordType.OID4VC_ISSUANCE, makeConfig()).map((p) => p.query.state)).toEqual([
+      'Completed',
+      'Error',
+    ])
+    expect(buildScanPlans(PurgeRecordType.OID4VC_VERIFICATION, makeConfig()).map((p) => p.query.state)).toEqual([
+      'ResponseVerified',
+      'Error',
+    ])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Eligibility
+// ---------------------------------------------------------------------------
+
+describe('purgeTenant — eligibility', () => {
+  test('keys TTL on updatedAt, not createdAt', async () => {
+    const { agent, deletedIds } = makeAgent({
+      recordsByState: {
+        done: [
+          // Created long ago but only just completed — an exchange that stayed open. Must survive.
+          { id: 'recently-active', createdAt: daysAgo(400), updatedAt: daysAgo(1) },
+          // Created recently but last touched beyond TTL — eligible.
+          { id: 'long-idle', createdAt: daysAgo(45), updatedAt: daysAgo(40) },
+        ],
+      },
+    })
+
+    await purgeTenant(agent as never, 'tenant-abc', makeConfig(), 'run-1')
+
+    expect(deletedIds).toEqual(['long-idle'])
+  })
+
+  test('a record with no usable timestamp is never eligible', async () => {
+    const { agent, deletedIds } = makeAgent({
+      recordsByState: { done: [{ id: 'no-timestamps' }, { id: 'bad-timestamp', updatedAt: 'not-a-date' }] },
+    })
+
+    await purgeTenant(agent as never, 'tenant-abc', makeConfig(), 'run-1')
+
+    expect(deletedIds).toEqual([])
+  })
+
+  test('falls back to createdAt when updatedAt is absent', async () => {
+    const { agent, deletedIds } = makeAgent({
+      recordsByState: { done: [{ id: 'legacy', createdAt: daysAgo(60) }] },
+    })
+
+    await purgeTenant(agent as never, 'tenant-abc', makeConfig(), 'run-1')
+
+    expect(deletedIds).toEqual(['legacy'])
+  })
+
+  test('reusable await-response OOB invitations are retained and counted separately', async () => {
+    const { agent, deletedIds } = makeAgent({
+      recordsByState: {
+        done: [{ id: 'oob-done', updatedAt: daysAgo(60) }],
+        'await-response': [
+          { id: 'oob-reusable', updatedAt: daysAgo(400), reusable: true },
+          { id: 'oob-single-use', updatedAt: daysAgo(60), reusable: false },
+        ],
+      },
+    })
+
+    const result = await purgeTenant(
+      agent as never,
+      'tenant-abc',
+      makeConfig({ recordTypes: [PurgeRecordType.DIDCOMM_OOB] }),
+      'run-1',
+    )
+
+    expect(deletedIds.sort()).toEqual(['oob-done', 'oob-single-use'])
+    expect(result.categories[0].retainedByPolicy).toBe(1)
+    expect(result.categories[0].eligible).toBe(2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cascade
+// ---------------------------------------------------------------------------
+
+describe('purgeTenant — DidCommMessageRecord cascade', () => {
+  test('deletes children before the parent', async () => {
+    const { agent, deletedIds } = makeAgent({
+      recordsByState: { done: [{ id: 'cred-1', updatedAt: daysAgo(60) }] },
+      children: { 'cred-1': [{ id: 'msg-1' }, { id: 'msg-2' }] },
+    })
+
+    const result = await purgeTenant(agent as never, 'tenant-abc', makeConfig(), 'run-1')
+
+    expect(deletedIds).toEqual(['msg-1', 'msg-2', 'cred-1'])
+    expect(result.childrenDeleted).toBe(2)
+    expect(result.parentsDeleted).toBe(1)
+  })
+
+  test('leaves the parent in place when a child delete fails, so no orphan is created', async () => {
+    const { agent, deletedIds } = makeAgent({
+      recordsByState: {
+        done: [
+          { id: 'cred-1', updatedAt: daysAgo(60) },
+          { id: 'cred-2', updatedAt: daysAgo(60) },
+        ],
+      },
+      children: { 'cred-1': [{ id: 'msg-1' }], 'cred-2': [{ id: 'msg-2' }] },
+      deleteErrors: { 'msg-1': new Error('storage locked') },
+    })
+
+    const result = await purgeTenant(agent as never, 'tenant-abc', makeConfig(), 'run-1')
+
+    // cred-1 survives alongside its message; cred-2 is fully cleaned. Next run retries cred-1.
+    expect(deletedIds).toEqual(['msg-2', 'cred-2'])
+    expect(result.failed).toBe(1)
+    expect(result.parentsDeleted).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Dry-run, idempotency, guards
+// ---------------------------------------------------------------------------
+
+describe('purgeTenant — modes and guards', () => {
+  test('dry-run deletes nothing but still reports the census', async () => {
+    const { agent, deletedIds, storageService } = makeAgent({
+      recordsByState: { done: [{ id: 'cred-1', updatedAt: daysAgo(60) }] },
+      children: { 'cred-1': [{ id: 'msg-1' }, { id: 'msg-2' }] },
+    })
+
+    const result = await purgeTenant(agent as never, 'tenant-abc', makeConfig({ dryRun: true }), 'run-1')
+
+    expect(storageService.deleteById).not.toHaveBeenCalled()
+    expect(deletedIds).toEqual([])
+    // Counts mirror what a live run would remove, so a dry-run census is directly comparable.
+    expect(result.eligible).toBe(1)
+    expect(result.parentsDeleted).toBe(1)
+    expect(result.childrenDeleted).toBe(2)
+    expect(result.dryRun).toBe(true)
+  })
+
+  test('RecordNotFoundError counts as an idempotent success, not a failure', async () => {
+    const { agent } = makeAgent({
+      recordsByState: { done: [{ id: 'cred-gone', updatedAt: daysAgo(60) }] },
+      deleteErrors: { 'cred-gone': new RecordNotFoundError('gone', { recordType: 'CredentialRecord' }) },
+    })
+
+    const result = await purgeTenant(agent as never, 'tenant-abc', makeConfig(), 'run-1')
+
+    expect(result.categories[0].alreadyAbsent).toBe(1)
+    expect(result.failed).toBe(0)
+  })
+
+  test('a batch where every delete genuinely fails aborts the record type', async () => {
+    const failing = Array.from({ length: 3 }, (_, index) => ({ id: `cred-${index}`, updatedAt: daysAgo(60) }))
+    const { agent, logger } = makeAgent({
+      recordsByState: { done: failing },
+      deleteErrors: Object.fromEntries(failing.map((record) => [record.id, new Error('storage locked')])),
+    })
+
+    const result = await purgeTenant(agent as never, 'tenant-abc', makeConfig({ batchSize: 3 }), 'run-1')
+
+    // All 3 failed in one batch, so the zero-progress guard fires instead of letting the run grind
+    // through the remaining states logging the same error.
+    expect(result.failed).toBe(3)
+    expect(result.parentsDeleted).toBe(0)
+    expect(logger.error).toHaveBeenCalledWith(
+      '[Purge] Record type failed — continuing with the next type',
+      expect.objectContaining({ recordType: PurgeRecordType.DIDCOMM_CREDENTIAL }),
+    )
+  })
+
+  test('a failure in one record type does not stop the others', async () => {
+    const { agent, deletedIds } = makeAgent({
+      recordsByState: {
+        done: [{ id: 'shared-done', updatedAt: daysAgo(60) }],
+      },
+      deleteErrors: { 'shared-done': new Error('storage locked') },
+    })
+    // Make the proof scan itself throw, and assert the credential type still ran.
+    agent.modules.didcomm.proofs.findAllByQuery = jest.fn(async () => {
+      throw new Error('proof scan exploded')
+    }) as never
+
+    const result = await purgeTenant(
+      agent as never,
+      'tenant-abc',
+      makeConfig({ recordTypes: [PurgeRecordType.DIDCOMM_PROOF, PurgeRecordType.DIDCOMM_OOB] }),
+      'run-1',
+    )
+
+    expect(result.categories.map((category) => category.recordType)).toEqual([
+      PurgeRecordType.DIDCOMM_PROOF,
+      PurgeRecordType.DIDCOMM_OOB,
+    ])
+    // OOB still processed its own tracks despite the proof scan failing.
+    expect(deletedIds).toEqual([])
+    expect(agent.modules.didcomm.oob.findAllByQuery).toHaveBeenCalled()
+  })
+
+  test('the per-tenant time budget truncates the run instead of overrunning', async () => {
+    const { agent, logger, deletedIds } = makeAgent()
+
+    // The budget is checked at plan and batch boundaries, so make the first scan outlast it: the
+    // credential category has three state plans, and the second one must find the budget spent.
+    let scanCount = 0
+    agent.modules.didcomm.credentials.findAllByQuery = jest.fn(async () => {
+      scanCount++
+      await new Promise((resolve) => setTimeout(resolve, 20))
+      return [{ id: `cred-${scanCount}`, updatedAt: daysAgo(60) }]
+    }) as never
+
+    const result = await purgeTenant(agent as never, 'tenant-abc', makeConfig({ timeBudgetMs: 10 }), 'run-1')
+
+    expect(result.truncated).toBe(true)
+    // Truncation stops further work rather than abandoning what already succeeded, and the
+    // untouched records are simply picked up by the next run.
+    expect(scanCount).toBe(1)
+    expect(deletedIds).toEqual(['cred-1'])
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[Purge] Time budget exhausted — tenant will resume on the next run',
+      expect.objectContaining({ timeBudgetMs: 10 }),
+    )
+  })
+
+  test('scans are state-scoped — findAllByQuery is never called with an empty query', async () => {
+    const { agent, queriedStates } = makeAgent({ recordsByState: {} })
+
+    await purgeTenant(
+      agent as never,
+      'tenant-abc',
+      makeConfig({ recordTypes: [PurgeRecordType.DIDCOMM_CREDENTIAL, PurgeRecordType.DIDCOMM_PROOF] }),
+      'run-1',
+    )
+
+    // Loading a whole category (`findAllByQuery({})`) is the flaw this replaces: its cost scales
+    // with total retained volume rather than the daily delta.
+    for (const state of [...queriedStates.credentials, ...queriedStates.proofs]) {
+      expect(state).toBeDefined()
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    for (const call of (agent.modules.didcomm.credentials.findAllByQuery as any).mock.calls) {
+      expect(Object.keys(call[0])).toEqual(['state'])
+    }
+  })
+
+  test('processes eligible records in batches of batchSize', async () => {
+    const records = Array.from({ length: 5 }, (_, index) => ({ id: `cred-${index}`, updatedAt: daysAgo(60) }))
+    const { agent, deletedIds, logger } = makeAgent({ recordsByState: { done: records } })
+
+    await purgeTenant(agent as never, 'tenant-abc', makeConfig({ batchSize: 2 }), 'run-1')
+
+    expect(deletedIds).toHaveLength(5)
+    const batchLogs = logger.debug.mock.calls.filter((call) => call[0] === '[Purge] Batch complete')
+    // 5 records at batchSize 2 → 3 batches.
+    expect(batchLogs).toHaveLength(3)
+  })
+})

--- a/src/purge/__tests__/PurgeStates.spec.ts
+++ b/src/purge/__tests__/PurgeStates.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * Upgrade-safety guard for the purge retention policy.
+ *
+ * The abandoned-proof sweep is ON by default, so any state it queries is deleted after the abandoned
+ * TTL. Deriving that list by exclusion from the Credo enum would fail OPEN: a state introduced by a
+ * future Credo release would land in it automatically and become purgeable with nobody having
+ * reviewed whether deleting it is safe.
+ *
+ * These tests force the decision instead. A Credo upgrade that adds a proof or credential state
+ * fails the build here until someone classifies it — terminal, abandonable, or neither.
+ *
+ * Runs under Jest ESM mode (see jest.config.base.ts).
+ */
+export {} // top-level await requires this file to be a module
+
+const { DidCommCredentialState, DidCommProofState } = await import('@credo-ts/didcomm')
+const {
+  DIDCOMM_CREDENTIAL_NON_TERMINAL_STATES,
+  DIDCOMM_CREDENTIAL_TERMINAL_STATES,
+  DIDCOMM_PROOF_ABANDONABLE_STATES,
+  DIDCOMM_PROOF_NON_TERMINAL_STATES,
+  DIDCOMM_PROOF_TERMINAL_STATES,
+} = await import('../PurgeStates')
+
+describe('proof state classification', () => {
+  test('every proof state Credo defines is explicitly classified', () => {
+    const classified = new Set([...DIDCOMM_PROOF_TERMINAL_STATES, ...DIDCOMM_PROOF_ABANDONABLE_STATES])
+    const unclassified = Object.values(DidCommProofState).filter((state) => !classified.has(state))
+
+    // If this fails after a Credo bump, decide deliberately: add the new state to
+    // DIDCOMM_PROOF_TERMINAL_STATES (a closed flow, purged at the terminal TTL), to
+    // DIDCOMM_PROOF_ABANDONABLE_STATES (a dead flow, purged at the shorter abandoned TTL), or to
+    // neither — in which case add it to the exclusion list below with a comment saying why.
+    expect(unclassified).toEqual([])
+  })
+
+  test('terminal and abandonable are disjoint', () => {
+    const overlap = DIDCOMM_PROOF_TERMINAL_STATES.filter((state) => DIDCOMM_PROOF_ABANDONABLE_STATES.includes(state))
+    expect(overlap).toEqual([])
+  })
+
+  test('the abandonable allowlist is a subset of the derived non-terminal set', () => {
+    // Catches a terminal state being pasted into the allowlist by mistake, and keeps the allowlist
+    // honest against the enum rather than drifting into free-text.
+    for (const state of DIDCOMM_PROOF_ABANDONABLE_STATES) {
+      expect(DIDCOMM_PROOF_NON_TERMINAL_STATES).toContain(state)
+    }
+  })
+
+  test('the allowlist is enumerated, not derived', () => {
+    // The engine must read from the explicit list. If someone "simplifies" it back to the derived
+    // one these become identical and the upgrade-safety property is silently lost — so assert the
+    // two are maintained separately even while their contents currently agree.
+    expect(DIDCOMM_PROOF_ABANDONABLE_STATES).not.toBe(DIDCOMM_PROOF_NON_TERMINAL_STATES)
+  })
+})
+
+describe('credential state classification', () => {
+  test('every credential state is either terminal or derived non-terminal', () => {
+    const classified = new Set([...DIDCOMM_CREDENTIAL_TERMINAL_STATES, ...DIDCOMM_CREDENTIAL_NON_TERMINAL_STATES])
+    const unclassified = Object.values(DidCommCredentialState).filter((state) => !classified.has(state))
+
+    expect(unclassified).toEqual([])
+  })
+
+  test('derivation is safe here because the non-terminal list is never queried', () => {
+    // Credentials have no abandoned sweep at all — a holder can still accept a pending offer after
+    // any TTL, so the issuer-side record is never purged while incomplete. That is why exclusion is
+    // acceptable for this list and not for the proof one.
+    const overlap = DIDCOMM_CREDENTIAL_TERMINAL_STATES.filter((state) =>
+      DIDCOMM_CREDENTIAL_NON_TERMINAL_STATES.includes(state),
+    )
+    expect(overlap).toEqual([])
+  })
+})

--- a/src/purge/decorators/SchedulePurge.ts
+++ b/src/purge/decorators/SchedulePurge.ts
@@ -2,6 +2,14 @@ import type { AgentMode, PurgeRecordType } from '../PurgeTypes'
 
 import { getNatsPurgeScheduler } from '../PurgeSchedulerFactory'
 
+/**
+ * @deprecated Registers a record for state-blind deletion at TTL via the dormant NATS
+ * schedule-at-create flow. `getNatsPurgeScheduler()` returns null unless `PURGE_NATS_ENABLED=true`,
+ * so with the default configuration this decorator is a no-op wrapper on the controller method.
+ *
+ * Retention is decided by the cron flow instead, which re-reads state at delete time. See
+ * `NatsPurgeScheduler` and INTEGRATION-PLAN-develop.md §4.4; the call sites go away with the flow.
+ */
 export function SchedulePurge(recordType: PurgeRecordType, idExtractor: (result: unknown) => string | undefined) {
   return function (_target: object, _key: string, descriptor: PropertyDescriptor) {
     const original = descriptor.value as (...args: unknown[]) => Promise<unknown>

--- a/src/purge/schedulers/CronPurgeScheduler.ts
+++ b/src/purge/schedulers/CronPurgeScheduler.ts
@@ -23,11 +23,14 @@ type DeletionNotifier = (
   recordId: string,
   tenantId: string,
   alreadyAbsent: boolean,
-) => Promise<void>
+) => void
 
 export class CronPurgeScheduler {
   private job: ScheduledTask | null = null
   private isRunning = false
+  /** Rotates which record type each tenant starts with, so a time-budget truncation cannot starve
+   *  the types at the back of a fixed order. */
+  private runCount = 0
 
   public async start(agent: Agent, config: PurgeConfig, webhookUrl: string | undefined): Promise<void> {
     const { cronConfig } = config
@@ -84,6 +87,7 @@ export class CronPurgeScheduler {
     const isShared = typeof (agent as any).modules?.tenants?.getAllTenants === 'function'
     const runId = randomUUID()
     const startedAt = Date.now()
+    const rotation = this.runCount++
 
     logger.info('[Purge] Cron scan started', {
       runId,
@@ -103,7 +107,9 @@ export class CronPurgeScheduler {
         try {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           await (agent as any).modules.tenants.withTenantAgent({ tenantId: tenant.id }, async (tenantAgent: Agent) => {
-            results.push(await purgeTenant(tenantAgent, tenant.id, cronConfig, runId, scopeNotifier(notify, tenant.id)))
+            results.push(
+              await purgeTenant(tenantAgent, tenant.id, cronConfig, runId, scopeNotifier(notify, tenant.id), rotation),
+            )
           })
         } catch (err) {
           // Tenants are isolated: one unopenable wallet must not stop the rest of the run.
@@ -112,7 +118,7 @@ export class CronPurgeScheduler {
         }
       }
     } else {
-      results.push(await purgeTenant(agent, '', cronConfig, runId, scopeNotifier(notify, '')))
+      results.push(await purgeTenant(agent, '', cronConfig, runId, scopeNotifier(notify, ''), rotation))
     }
 
     // Per-run audit record. This — not the deprecated per-record webhook — is the purge's
@@ -138,19 +144,18 @@ export class CronPurgeScheduler {
   private buildDeletionNotifier(agent: Agent, webhookUrl: string | undefined): DeletionNotifier | undefined {
     if (!webhookUrl) return undefined
 
-    return async (recordType, recordId, tenantId, alreadyAbsent) => {
+    return (recordType, recordId, tenantId, alreadyAbsent) => {
       const status = alreadyAbsent ? PurgeDeletionStatus.ALREADY_ABSENT : PurgeDeletionStatus.DELETED
-      try {
-        await sendPurgeWebhook(webhookUrl, recordId, recordType, tenantId, status, agent.config.logger)
-      } catch (err) {
-        // Notification is best-effort — a webhook failure must never make a completed delete look
-        // like a failed purge.
+      // Fire-and-forget. sendPurgeWebhook retries [1s, 5s, 30s] with a 10s per-attempt timeout, so
+      // awaiting it would stall the sequential delete loop by up to ~46s per record against an
+      // endpoint that does not exist. Delivery is best-effort; the per-run audit log is the record.
+      void sendPurgeWebhook(webhookUrl, recordId, recordType, tenantId, status, agent.config.logger).catch((err) => {
         agent.config.logger.warn('[Purge] Webhook delivery failed after deletion', {
           recordId,
           recordType,
           error: (err as Error)?.message,
         })
-      }
+      })
     }
   }
 }

--- a/src/purge/schedulers/CronPurgeScheduler.ts
+++ b/src/purge/schedulers/CronPurgeScheduler.ts
@@ -51,8 +51,9 @@ export class CronPurgeScheduler {
 
     if (cronConfig.dryRun) {
       agent.config.logger.warn(
-        '[Purge] DRY-RUN mode — the cron purge will scan and report but delete nothing. ' +
-          'Set PURGE_CRON_DRY_RUN=false to enable deletion.',
+        '[Purge] DRY-RUN mode (PURGE_CRON_DRY_RUN=true) — the cron purge will scan and report a census ' +
+          'but delete nothing, so retained data will keep growing. Unset PURGE_CRON_DRY_RUN once the ' +
+          'census has been reviewed.',
       )
     } else {
       agent.config.logger.warn('[Purge] LIVE mode — the cron purge will permanently delete records past TTL.')

--- a/src/purge/schedulers/CronPurgeScheduler.ts
+++ b/src/purge/schedulers/CronPurgeScheduler.ts
@@ -1,14 +1,29 @@
-import type { PurgeConfig } from '../PurgeTypes'
+/**
+ * Steady-state purge trigger. Owns scheduling, tenant enumeration and the per-run audit log; all
+ * scanning and deleting lives in `PurgeEngine`.
+ *
+ * This is the "Tier B" purge from INTEGRATION-PLAN-develop.md §3 — the recurring job runs inside the
+ * agent process precisely so no second service needs a copy of `WALLET_KEY` and no second writer
+ * touches the Askar store. Heavy one-off backfills stay with the operator-run `credo-data-purge`
+ * tool (Tier A).
+ */
+import type { PurgeTenantResult } from '../PurgeEngine'
+import type { PurgeConfig, PurgeRecordType } from '../PurgeTypes'
 import type { Agent } from '@credo-ts/core'
 import type { ScheduledTask } from 'node-cron'
 
-import { RecordNotFoundError } from '@credo-ts/core'
-import { OpenId4VcIssuanceSessionRepository, OpenId4VcVerificationSessionRepository } from '@credo-ts/openid4vc'
 import cron from 'node-cron'
+import { randomUUID } from 'node:crypto'
 
-import { deletePurgeRecord } from '../PurgeDeleteRecord'
-import { PurgeRecordType } from '../PurgeTypes'
-import { sendPurgeWebhook, PurgeDeletionStatus } from '../PurgeWebhook'
+import { purgeTenant } from '../PurgeEngine'
+import { PurgeDeletionStatus, sendPurgeWebhook } from '../PurgeWebhook'
+
+type DeletionNotifier = (
+  recordType: PurgeRecordType,
+  recordId: string,
+  tenantId: string,
+  alreadyAbsent: boolean,
+) => Promise<void>
 
 export class CronPurgeScheduler {
   private job: ScheduledTask | null = null
@@ -18,6 +33,8 @@ export class CronPurgeScheduler {
     const { cronConfig } = config
 
     this.job = cron.schedule(cronConfig.cronSchedule, () => {
+      // Overlapping runs would double the DB load the throttle exists to cap, so a tick that
+      // arrives while the previous run is still going is dropped rather than queued.
       if (this.isRunning) {
         agent.config.logger.warn('[Purge] Cron scan still running — skipping this tick')
         return
@@ -32,10 +49,25 @@ export class CronPurgeScheduler {
         })
     })
 
+    if (cronConfig.dryRun) {
+      agent.config.logger.warn(
+        '[Purge] DRY-RUN mode — the cron purge will scan and report but delete nothing. ' +
+          'Set PURGE_CRON_DRY_RUN=false to enable deletion.',
+      )
+    } else {
+      agent.config.logger.warn('[Purge] LIVE mode — the cron purge will permanently delete records past TTL.')
+    }
+
     agent.config.logger.info('[Purge] CronPurgeScheduler started', {
       cronSchedule: cronConfig.cronSchedule,
       ttlSeconds: cronConfig.ttlSeconds,
       recordTypes: cronConfig.recordTypes,
+      dryRun: cronConfig.dryRun,
+      batchSize: cronConfig.batchSize,
+      throttleMs: cronConfig.throttleMs,
+      timeBudgetMs: cronConfig.timeBudgetMs,
+      staleProofEnabled: cronConfig.staleProofEnabled,
+      staleProofTtlSeconds: cronConfig.staleProofEnabled ? cronConfig.staleProofTtlSeconds : undefined,
     })
   }
 
@@ -46,133 +78,88 @@ export class CronPurgeScheduler {
 
   private async runScan(agent: Agent, config: PurgeConfig, webhookUrl: string | undefined): Promise<void> {
     const logger = agent.config.logger
+    const { cronConfig } = config
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const isShared = typeof (agent as any).modules?.tenants?.getAllTenants === 'function'
+    const runId = randomUUID()
+    const startedAt = Date.now()
 
-    logger.info('[Purge] Cron scan started', { agentMode: isShared ? 'shared' : 'dedicated' })
+    logger.info('[Purge] Cron scan started', {
+      runId,
+      agentMode: isShared ? 'shared' : 'dedicated',
+      dryRun: cronConfig.dryRun,
+    })
 
-    let totalDeleted = 0
+    const notify = this.buildDeletionNotifier(agent, webhookUrl)
+    const results: PurgeTenantResult[] = []
+    let tenantsFailed = 0
 
     if (isShared) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const tenants: Array<{ id: string }> = await (agent as any).modules.tenants.getAllTenants()
 
       for (const tenant of tenants) {
         try {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           await (agent as any).modules.tenants.withTenantAgent({ tenantId: tenant.id }, async (tenantAgent: Agent) => {
-            const count = await this.scanTenant(tenantAgent, tenant.id, config, webhookUrl)
-            totalDeleted += count
+            results.push(await purgeTenant(tenantAgent, tenant.id, cronConfig, runId, scopeNotifier(notify, tenant.id)))
           })
-        } catch (err: any) {
-          logger.error('[Purge] Failed to scan tenant', { tenantId: tenant.id, error: err?.message })
+        } catch (err) {
+          // Tenants are isolated: one unopenable wallet must not stop the rest of the run.
+          tenantsFailed++
+          logger.error('[Purge] Failed to purge tenant', { runId, tenantId: tenant.id, error: (err as Error)?.message })
         }
       }
     } else {
-      totalDeleted = await this.scanTenant(agent, '', config, webhookUrl)
+      results.push(await purgeTenant(agent, '', cronConfig, runId, scopeNotifier(notify, '')))
     }
 
-    logger.info('[Purge] Cron scan completed', { totalDeleted })
+    // Per-run audit record. This — not the deprecated per-record webhook — is the purge's
+    // notification surface (INTEGRATION-PLAN-develop.md §4.5).
+    logger.info('[Purge] Cron scan completed', {
+      runId,
+      dryRun: cronConfig.dryRun,
+      durationMs: Date.now() - startedAt,
+      tenantsProcessed: results.length,
+      tenantsFailed,
+      tenantsTruncated: results.filter((result) => result.truncated).length,
+      eligible: sum(results.map((result) => result.eligible)),
+      parentsDeleted: sum(results.map((result) => result.parentsDeleted)),
+      childrenDeleted: sum(results.map((result) => result.childrenDeleted)),
+      failed: sum(results.map((result) => result.failed)),
+    })
   }
 
-  private async scanTenant(
-    tenantAgent: Agent,
-    tenantId: string,
-    config: PurgeConfig,
-    webhookUrl: string | undefined,
-  ): Promise<number> {
-    let deleted = 0
-    const { cronConfig } = config
+  /**
+   * @deprecated Builds the per-record webhook notifier, or returns undefined when the webhook is
+   * disabled (the default). Retained for reversibility only — see `PurgeWebhook.ts`.
+   */
+  private buildDeletionNotifier(agent: Agent, webhookUrl: string | undefined): DeletionNotifier | undefined {
+    if (!webhookUrl) return undefined
 
-    for (const recordType of cronConfig.recordTypes) {
+    return async (recordType, recordId, tenantId, alreadyAbsent) => {
+      const status = alreadyAbsent ? PurgeDeletionStatus.ALREADY_ABSENT : PurgeDeletionStatus.DELETED
       try {
-        const expiredIds = await this.queryExpiredRecords(tenantAgent, recordType, cronConfig.ttlSeconds)
-
-        for (const recordId of expiredIds) {
-          if (await this.deleteAndNotify(tenantAgent, recordId, recordType, tenantId, webhookUrl)) {
-            deleted++
-          }
-        }
-      } catch (err: any) {
-        tenantAgent.config.logger.error('[Purge] Error scanning record type', {
-          tenantId,
+        await sendPurgeWebhook(webhookUrl, recordId, recordType, tenantId, status, agent.config.logger)
+      } catch (err) {
+        // Notification is best-effort — a webhook failure must never make a completed delete look
+        // like a failed purge.
+        agent.config.logger.warn('[Purge] Webhook delivery failed after deletion', {
+          recordId,
           recordType,
-          error: err?.message,
+          error: (err as Error)?.message,
         })
       }
     }
-
-    return deleted
   }
+}
 
-  private async queryExpiredRecords(agent: Agent, recordType: PurgeRecordType, ttlSeconds: number): Promise<string[]> {
-    const cutoffMs = Date.now() - ttlSeconds * 1000
-    const ids: string[] = []
+function scopeNotifier(notify: DeletionNotifier | undefined, tenantId: string) {
+  if (!notify) return undefined
+  return (recordType: PurgeRecordType, recordId: string, alreadyAbsent: boolean) =>
+    notify(recordType, recordId, tenantId, alreadyAbsent)
+}
 
-    switch (recordType) {
-      case PurgeRecordType.DIDCOMM_CREDENTIAL: {
-        const records = await (agent as any).modules.didcomm.credentials.findAllByQuery({})
-        for (const r of records) {
-          if (r.createdAt && new Date(r.createdAt).getTime() < cutoffMs) ids.push(r.id)
-        }
-        break
-      }
-
-      case PurgeRecordType.DIDCOMM_PROOF: {
-        const records = await (agent as any).modules.didcomm.proofs.findAllByQuery({})
-        for (const r of records) {
-          if (r.createdAt && new Date(r.createdAt).getTime() < cutoffMs) ids.push(r.id)
-        }
-        break
-      }
-
-      case PurgeRecordType.OID4VC_ISSUANCE: {
-        const repo = agent.dependencyManager.resolve(OpenId4VcIssuanceSessionRepository)
-        const records = await repo.findByQuery(agent.context, {})
-        for (const r of records) {
-          if (r.createdAt && new Date(r.createdAt).getTime() < cutoffMs) ids.push(r.id)
-        }
-        break
-      }
-
-      case PurgeRecordType.OID4VC_VERIFICATION: {
-        const repo = agent.dependencyManager.resolve(OpenId4VcVerificationSessionRepository)
-        const records = await repo.findByQuery(agent.context, {})
-        for (const r of records) {
-          if (r.createdAt && new Date(r.createdAt).getTime() < cutoffMs) ids.push(r.id)
-        }
-        break
-      }
-    }
-
-    return ids
-  }
-
-  private async deleteAndNotify(
-    agent: Agent,
-    recordId: string,
-    recordType: PurgeRecordType,
-    tenantId: string,
-    webhookUrl: string | undefined,
-  ): Promise<boolean> {
-    const logger = agent.config.logger
-    let status: PurgeDeletionStatus
-
-    try {
-      await deletePurgeRecord(agent, recordType, recordId)
-      logger.info('[Purge] Record deleted by cron', { recordId, recordType, tenantId })
-      status = PurgeDeletionStatus.DELETED
-    } catch (err: any) {
-      if (err instanceof RecordNotFoundError) {
-        logger.warn('[Purge] Record already absent — skipping', { recordId, recordType })
-        status = PurgeDeletionStatus.ALREADY_ABSENT
-      } else {
-        logger.error('[Purge] Failed to delete record', { recordId, recordType, error: err?.message })
-        return false
-      }
-    }
-
-    if (webhookUrl) {
-      await sendPurgeWebhook(webhookUrl, recordId, recordType, tenantId, status, logger)
-    }
-
-    return true
-  }
+function sum(values: number[]): number {
+  return values.reduce((total, value) => total + value, 0)
 }

--- a/src/purge/schedulers/CronPurgeScheduler.ts
+++ b/src/purge/schedulers/CronPurgeScheduler.ts
@@ -67,8 +67,8 @@ export class CronPurgeScheduler {
       batchSize: cronConfig.batchSize,
       throttleMs: cronConfig.throttleMs,
       timeBudgetMs: cronConfig.timeBudgetMs,
+      abandonedTtlSeconds: cronConfig.abandonedTtlSeconds,
       staleProofEnabled: cronConfig.staleProofEnabled,
-      staleProofTtlSeconds: cronConfig.staleProofEnabled ? cronConfig.staleProofTtlSeconds : undefined,
     })
   }
 

--- a/src/purge/schedulers/NatsPurgeScheduler.ts
+++ b/src/purge/schedulers/NatsPurgeScheduler.ts
@@ -26,6 +26,22 @@ import { PurgeWorker } from '../PurgeWorker'
 
 const sc = StringCodec()
 
+/**
+ * @deprecated Schedule-at-create purge flow. Dormant by default and refused at startup unless
+ * `PURGE_NATS_ACK_STATE_BLIND=true` is also set (see `PurgeConfigValidator`). Retained only so the
+ * decision to standardise on cron stays reversible; slated for removal once cron parity is proven in
+ * production. See INTEGRATION-PLAN-develop.md §4.4.
+ *
+ * Why it is not the recommended flow:
+ *   - The deletion time is fixed when the record is *created*, so the job fires **state-blind** at
+ *     TTL and can delete an exchange that is still in flight. The cron flow re-checks state at
+ *     delete time, which is what makes the retention policy in `PurgeStates.ts` enforceable.
+ *   - It depends on the JetStream `allow_msg_schedules` feature.
+ *   - Its `purge.deletion.complete` webhook targets a platform endpoint that does not exist.
+ *
+ * It does share the storage-level delete fix, so if it is ever enabled it will no longer destroy
+ * stored holder credentials — but it remains state-blind.
+ */
 export class NatsPurgeScheduler {
   private nc: NatsConnection | null = null
   private js: JetStreamClient | null = null

--- a/src/purge/schedulers/NatsPurgeScheduler.ts
+++ b/src/purge/schedulers/NatsPurgeScheduler.ts
@@ -85,6 +85,11 @@ export class NatsPurgeScheduler {
   ): Promise<void> {
     if (!this.js) throw new Error('[Purge] NatsPurgeScheduler not started')
 
+    // Consumers are only provisioned for the configured record types, so publishing for an excluded
+    // type produces execution messages nothing will ever consume. They sit in the stream until
+    // max_age and would all be replayed at once if that type were later enabled.
+    if (!this.recordTypes.includes(recordType)) return
+
     const fireAt = new Date(Date.now() + this.ttlSeconds * 1000).toISOString()
     const job: PurgeJob = { recordId, recordType, tenantId, agentMode, scheduledAt: fireAt }
 


### PR DESCRIPTION
Implements `credo-data-purge/INTEGRATION-PLAN-develop.md` — brings the proven semantics of the operator batch tool into the in-process purge, so steady-state pruning needs **no separate service, no second holder of `WALLET_KEY`, and no second writer on the Askar store** (plan §3, Tier B). Heavy one-off backfills stay with `credo-data-purge` (Tier A).

Two commits: the credential-safety fix is isolated so it can be reviewed on its own, per the plan's rollout order.

## The bug that mattered most (§4.1)

The purge deleted DIDComm exchange records via the protocol API:

```ts
await agent.modules.didcomm.credentials.deleteById(recordId)
```

`DidCommBaseCredentialProtocol.delete()` defaults `deleteAssociatedCredentials` to `true`:

```js
// node_modules/@credo-ts/didcomm/.../DidCommBaseCredentialProtocol.mjs:97
const deleteAssociatedCredentials = options?.deleteAssociatedCredentials ?? true
```

So a routine retention purge also destroyed the stored `W3cCredentialRecord` / `AnonCredsCredentialRecord`. On a holder cloud wallet that is **loss of the holder's actual credentials**, not just completed exchange bookkeeping. Deletes now go through `StorageService.deleteById`, which removes the named record and nothing else. The OID4VC session repositories were already parent-only and are unchanged.

## Retention policy (§4.2)

Every state is written as a Credo enum member, so a Credo rename breaks the build rather than silently matching nothing. Non-terminal lists are *derived* by exclusion, so a newly added Credo state fails safe.

| Record type | Purged | TTL | Retained |
|---|---|---|---|
| Credential exchange | `done`, `abandoned`, `declined` | 30d | every non-terminal state — **structurally unreachable**, not merely disabled |
| Proof exchange | terminal | 30d | — |
| Proof exchange | non-terminal (on by default) | **7d** | in-flight below the abandoned TTL |
| OOB | `done` (any reusability) | 30d | — |
| OOB | `await-response`, non-reusable | **7d** | reusable `await-response` (live invitation URL / QR), `initial`, `prepare-response` |
| OID4VC issuance | `Completed`/`Error` **without** status-list info | 30d | **any session carrying `StatusListInfo` — it is the revocation handle** |
| OID4VC verification | `ResponseVerified`, `Error` | 30d | all in-flight |
| Connections, stored credentials | — | — | never touched |

Two TTLs, because completed and abandoned flows are different data classes: a completed exchange is an audit record of a verification that happened; an unanswered proof request or unscanned invitation has no future use. `PURGE_CRON_TTL_SECONDS` (30d) governs the former, `PURGE_CRON_ABANDONED_TTL_SECONDS` (7d) the latter, with a 3600s floor guarding the only real hazard — deleting a flow a holder is mid-response to.

A holder can still accept a pending offer (`offer-received`) after any TTL, so deleting the issuer-side record is unrecoverable — hence credentials get no stale policy at all. A holder answering a *deleted proof request* just gets an error and the verifier re-requests, so proofs can have one.

TTL is keyed on **`updatedAt`** (last activity), not `createdAt` — verified that `AskarStorageService` stamps it on every `save`/`update`/`updateByIdWithLock`, which discharges the §9 open question.

## Policy calibrated against a production drain

The retention numbers are measured, not estimated — from the July 2026 drain, which removed roughly
five-eighths of all stored records. Proportions below; the underlying census is internal.

| Category | Share of what was purged | Eligible |
|---|---|---|
| **Out-of-band** | largest single category | ~91% |
| DIDComm messages | second largest | ~60% |
| Proof exchanges | third largest | ~75% |
| Credential exchanges | marginal | ~6% |

- **Proof `request-sent` was ~68% of all proof exchanges** and ~10% of the whole wallet. Hence non-terminal proof sweeping is on by default; what survived a 60-day floor implies a daily arrival rate at which 7 days holds roughly a thirteenth of what a 90-day default would.
- **OOB was the largest purgeable category**, ~91% eligible. `create-request-oob` mints one per connectionless proof request, so the non-reusable `await-response` records are the other half of the `request-sent` pile — they get the same 7-day TTL, otherwise each abandoned request is only half cleared.
- **Not just storage.** The same drain cut proof share→received latency on the largest tenant by roughly an order of magnitude.
- **`presentation-received` was ~0.03% of incomplete proofs**, and the other four non-terminal proof states were empty — so an early/late state split was considered and dropped as complexity that buys nothing.
- **Credentials are mostly not purgeable** (~6%): `offer-sent` and `credential-issued`, both growing, are the large majority of that category. Left retained — that's a policy call on national-identity data, and the next lever if more is needed.

### Defect this data exposed

Purging OID4VC issuance sessions **destroyed the ability to revoke**. `revokeBySessionId` reads `issuanceMetadata.StatusListInfo` off the session record for `{listId, index, issuerDid}`; there is no other copy, so purging a `Completed` session made that credential permanently unrevocable. Sessions carrying status-list info are now retained indefinitely; those without it and `Error` sessions still age out. The batch tool never purged OID4VC, so no measured volume argued the other way.

## Scan and delete (§4.3, §8)

- **State-scoped scans** (`findByQuery({ state })`, an indexed tag) replace `findAllByQuery({})`. Once terminal records past TTL are purged every run, the terminal set stays bounded to ~one TTL window — that is what makes a daily run cheap. Cost tracks the daily delta, not total retained volume.
- **No `{limit, offset}` paging within a plan.** Askar applies no stable sort across separate scan calls, so paging a category over multiple queries silently skips or double-counts rows (measured and documented in the batch tool). Batching and throttling apply to the *deletes*: `PURGE_CRON_BATCH_SIZE=100`, `PURGE_CRON_THROTTLE_MS=250`.
- **Per-parent message cascade, children first.** If a child delete fails the parent is left in place and retried next run, so a partial delete can never leave an orphan.
- **Dry-run available as an opt-in census** (`PURGE_CRON_DRY_RUN=true`), reporting the full count of what would go so a census is directly comparable to a live run. It is deliberately *not* the default — see the note below.
- Idempotent `RecordNotFoundError` handling; zero-progress guard aborts a record type when every delete in a batch genuinely failed; failures isolated per record type and per tenant.
- Optional per-tenant time budget.

### Three deliberate divergences from the batch tool

Each because this code shares a process and DB pool with the live agent:

1. **No global orphan sweep.** It is O(total records) per run and must not sit in a daily in-process job (§8). The per-parent cascade prevents *new* orphans. Legacy orphans from past bulk deletes remain a one-off `credo-data-purge` job.
2. **Sequential deletes within a batch** instead of `Promise.allSettled` over all 100 — those Askar sessions would compete with live request traffic. Throughput is not the constraint here.
3. **Strict children-before-parent ordering.** The batch tool submits both in one settled batch and relies on its orphan sweep as backstop; without that backstop the ordering has to be strict.

## Why dry-run is not the default

`credo-data-purge` defaults to dry-run and that is right for it: an operator runs it, reads the census, and re-runs live within seconds. A cron job has no human in that loop, so the same default yields a subsystem that looks enabled, logs healthy runs and deletes nothing — with the storage growth found weeks later. That is a worse steady-state failure mode than the one it guards against, and it is the exact problem the purge exists to solve.

Dry-run also is not what makes this job safe. The guarantees are structural: the storage-level delete cannot reach a stored credential, state-scoped scans cannot reach an in-flight exchange, the retention rules cannot reach a reusable invitation, children-before-parent ordering cannot orphan a message. `PURGE_ENABLED` + `PURGE_CRON_ENABLED` is already an unambiguous statement of intent.

The mode stays because it has two real uses: the pre-enable census (rollout step 5) and §8's measure-don't-guess decision on whether the largest tenant needs the batch tool instead — and for that, the cron's own dry-run beats the batch tool's, since it exercises the real state-scoped queries.

Since flipping the default would make a typo in `PURGE_CRON_DRY_RUN` land on live deletion, that flag is parsed **strictly**: only `true`, `false` or unset are accepted, anything else fails startup. This removes the typo hazard in both directions instead of trading one silent failure for another. The other purge booleans stay lenient, where a typo leaves the feature off — the harmless side.

## Open decisions from §9 — as agreed

- **§4.4 NATS schedule-at-create → kept dormant + `@deprecated`.** It fixes each record's deletion time at *creation*, so it fires without re-checking state. It now refuses to start unless `PURGE_NATS_ACK_STATE_BLIND=true` is set alongside `PURGE_NATS_ENABLED=true`. It shares the storage-level delete fix, but remains state-blind and does not cascade message children. Reversible; remove once cron parity is proven in prod.
- **§4.5 webhook → kept, default OFF + `@deprecated`.** Confirmed there is **no** `/purge/*` receiver on the platform; the platform's purge notification path is the JetStream `presentation.purged` event in `apps/notification/src/nats/jetstream.consumer.ts`, a different mechanism. `PURGE_WEBHOOK_ENABLED` now requires the literal `"true"` (previously on unless explicitly `"false"`, i.e. a dangling POST per deleted record). Replaced by a structured per-run / per-tenant audit log.

## Scope note

`didcomm_oob` is added as a **new** purgeable record type. §4.2 specifies OOB retention rules, and without it OOB records accumulate forever and require recurring operator batch runs — which defeats the plan's "no separate service" goal. It is in the default type set; the whole purge subsystem remains off by default (`PURGE_ENABLED` unset).

## Testing

59 new tests across 4 suites; full suite 103 passed / 9 suites. `yarn check-types`, `yarn check-types:test` clean; zero lint errors in `src/purge`.

- `PurgeDeleteRecord.spec.ts` — the §4.1 regression test the plan asks for: protocol APIs never called, exactly one record class deleted, no `W3c`/`AnonCreds` record touched, `RecordNotFoundError` propagated.
- `PurgeEngine.spec.ts` — no credential plan for any non-terminal state even with stale purging on; stale proof TTL strictly older; reusable OOB retained; `updatedAt` over `createdAt` (incl. the long-running-exchange case); children-before-parent and the failed-child-leaves-parent case; dry-run census; idempotency; zero-progress guard; per-type isolation; time-budget truncation; state-scoped queries; batch boundaries.
- `PurgeConfig.spec.ts` — defaults (incl. that an enabled purge actually deletes, and that a malformed `PURGE_CRON_DRY_RUN` fails startup), malformed-value rejection, and the two startup guards (the NATS guard fires before any broker connection).

## Second review pass

Six of seven findings valid and fixed; the seventh answered on its thread.

- **OOB deletion leaked mediator routing (high).** `DidCommOutOfBandApi.deleteById()` deregisters recipient keys from the mediator when the record has a `mediatorId`, only inline services, and no related connection. The 7-day `await-response` track is exactly that case and `create-request-oob` always sets `mediatorId` — so a raw delete would have left keys registered at the mediator forever, on the largest category by volume. OOB now goes through the API; it cascades nothing else, so the credential hazard does not apply.
- **Eligibility now re-checked at delete time (high).** The page is a snapshot processed sequentially behind a throttle, so a record could move on while waiting its turn and still be deleted on stale state. Each record is re-read and re-evaluated against its plan immediately before deletion. This also makes the "cron decides at delete time" claim — used to justify deprecating the NATS flow — actually true; it was overclaiming before.
- **Explicit allowlist for abandonable proof states (upgrade safety).** Deriving by exclusion fails *open* now the sweep is default-on: a state added by a future Credo release would silently become purgeable. `PurgeStates.spec.ts` now fails the build until any new state is deliberately classified.
- **Repository-level deletes restore lifecycle events (low).** `Repository.deleteById` is `storageService.deleteById` plus a `RecordDeleted` emit — no extra read, no cascade — so it is free and keeps the safety property.
- **Unreachable startup guard (operability).** `PURGE_ENABLED=true` with no mode selected returned `undefined`, making the validator's error dead code and turning a typo into a silently disabled purge. Now throws.
- **NATS worker no longer orphans messages (medium).** That path had no cascade, so an acknowledged deletion orphaned every associated `DidCommMessageRecord`. It now runs the same children-before-parent cascade.
- **NATS scheduling honours the record-type filter (low).** Excluded types no longer publish messages that nothing consumes and would replay in bulk if later enabled.

## First review pass

Two issues found and fixed, plus five assumptions verified against Credo 0.6.2 rather than assumed.

**Bug — an already-gone message child aborted the cascade.** `RecordNotFoundError` from a *child* delete escaped `deleteDidCommMessageChildren` and hit the handler written for the *parent*, so the parent was left undeleted while being reported as a successful already-absent deletion (and firing an `ALREADY_ABSENT` webhook for a record that still existed). It self-healed across runs, but on a wallet with a partially-completed previous run every run made only partial progress while the summary looked clean — and if the first child of every record in a batch was already gone, `alreadyAbsent` incremented for the whole batch, so the zero-progress guard saw "progress" and the run stalled silently. Absent children are now skipped and counted as removed; only real failures block the parent.

**Operability — an invalid `PURGE_CRON_SCHEDULE` crashed startup** with `Cannot read properties of undefined (reading 'replace')` from inside node-cron, naming neither the purge nor the schedule. Now validated up front with a message naming the variable, the value and an example.

Verified, no change needed:

- `await-response` is reached only by `createInvitation`, so the 7-day track touches **only invitations we issued that nobody accepted**. Receiver-side records sit in `initial`/`prepare-response` and no track purges them — a holder's pending invitations are safe.
- OOB records never own `DidCommMessageRecord` children, so skipping the cascade for them creates no orphans.
- `reusable` is a real property defaulting to `false`, so the retention predicate matches the right field rather than silently never firing.
- `state` is a queryable tag on credential, proof and OOB records, so state-scoped scans hit an index instead of returning nothing.
- node-cron tasks start on creation; no explicit `.start()` needed.

### Known limitation

OID4VC issuance sessions carrying `StatusListInfo` are retained indefinitely, so that category's scan set grows without bound over time — the state-scoped bounding argument in §8 does not apply to it. Currently zero-cost (OID4VC is unused in this deployment) but worth revisiting if OID4VC issuance is adopted at volume.

## Not done in this PR

Plan rollout steps 5–6 are operational and unchanged by code: snapshot-validate (dry-run census → one real delete on a copy → verify stored credentials survive) before enabling, then enable off-peak on one tenant and broaden. Suggested first config:

```
PURGE_ENABLED=true
PURGE_CRON_ENABLED=true
PURGE_CRON_DRY_RUN=true          # one-time census; REMOVE this line once reviewed
PURGE_CRON_SCHEDULE=0 3 * * *    # off-peak
```

Leave the dry-run line in only long enough to read one run's summary — while it is set, nothing is being deleted.

The §1 Askar-binding risk (`0.4.3` live vs `0.6.0` batch tool) is untouched and unrelated — this code stays on the agent's own `0.4.3`.





