### PR TITLE
fix(issuance): drop conflicting pthid from OOB credential offer attachment

### DIFF
--- a/src/controllers/didcomm/credentials/CredentialController.ts
+++ b/src/controllers/didcomm/credentials/CredentialController.ts
@@ -222,6 +222,17 @@ export class CredentialController extends Controller {
 
       const credentialMessage = offerOob.message
 
+      // RFC 0434 requires a message inside `requests~attach` to carry either no parent
+      // thread id or one equal to the invitation's `@id` — the holder sets it to the
+      // invitation id itself. The patch above put `parentThreadId` on `~thread.pthid`,
+      // which every conformant holder rejects on receipt ("...contains parent thread id X
+      // that does not match the invitation id Y"), silently discarding the offer while the
+      // connection still completes. Correlation stays on the exchange record (also set by
+      // the patch), so re-thread the attached message with the thread id only.
+      if (outOfBandOption.parentThreadId) {
+        credentialMessage.setThread({ threadId: offerOob.credentialExchangeRecord.threadId })
+      }
+
       const outOfBandRecord = await request.agent.modules.didcomm.oob.createInvitation({
         label: outOfBandOption.label,
         messages: [credentialMessage],
@@ -241,6 +252,7 @@ export class CredentialController extends Controller {
         outOfBandRecordId: outOfBandRecord.id,
         credentialExchangeRecordId: offerOob.credentialExchangeRecord.id,
         credentialRequestThId: offerOob.credentialExchangeRecord.threadId,
+        credentialRequestParentThId: offerOob.credentialExchangeRecord.parentThreadId,
         invitationDid,
       }
     } catch (error) {


### PR DESCRIPTION
## Problem

OOB (QR) issuance of a credential offer never reaches the holder when a `parentThreadId` is supplied. The DIDComm connection forms normally, but the credential offer prompt never appears in the wallet. Issuing the same credential over an existing `connectionId` works.

This has been latent since the `parentThreadId` threading was introduced (present on `pipeline-implementation` too) — it only surfaced now because the OOB path wasn't in use.

## Root cause

`patches/@credo-ts+didcomm+0.6.2.patch` sets `parentThreadId` on **both** the exchange record and the offer message's `~thread.pthid`:

```js
if (parentThreadId) {
  offerMessage.setThread({ threadId: credentialExchangeRecord.threadId, parentThreadId })
  credentialExchangeRecord.parentThreadId = parentThreadId
}
```

That is correct for the connection-based `offerCredential` path. But `createOfferOob` then embeds the same message in the invitation's `requests~attach`, and RFC 0434 requires an attached message to carry either no parent thread id or one equal to the invitation's `@id`. So on receipt the holder throws:

```
Out of band invitation requests~attach message contains parent thread id <X>
that does not match the invitation id <Y>
```

Credo raises this in `OutOfBandApi.ensureParentThreadId` in **both 0.5.x and 0.6.x**, so it is not version skew between our agent (0.6.2) and the wallet (0.5.18) — every conformant holder rejects it. Upgrading the wallet would not help; the fix belongs on the issuer.

Observed behaviour matches exactly:

| Scenario | What happens |
|---|---|
| First scan (new connection) | Offer is deferred behind `returnWhenIsConnected(...).then(emitWithConnection)`; the throw lands in the `.catch` and is only logged as `Promise waiting for the connection to be complete failed.` Connection completes, offer silently dropped. |
| Second scan (connection reuse, `isReady`) | `emitWithConnection` is awaited, so the throw propagates through `acceptInvitationFromUrl` and surfaces as a generic wallet error. Reuse is shown, still no offer. |
| Issuance over `connectionId` | No OOB invitation exists, `ensureParentThreadId` never runs, `pthid` is exactly the intended correlation. Works. |

`parentThreadId` reaches this endpoint from the client-service issuance flow → agent-service → platform `issuance.service.ts`, so every OOB offer carrying one failed deterministically.

## Change

`src/controllers/didcomm/credentials/CredentialController.ts` — `createOfferOob`:

1. **Re-thread the attached message with the thread id only** when `parentThreadId` was supplied, dropping the offending `pthid`. The holder then sets `~thread.pthid = invitation.@id` itself, as the RFC requires.
2. **Return `credentialRequestParentThId`.** `client-service/issuance-service` already reads `oobOfferResponse.data.credentialRequestParentThId` to populate `issueCredParentThreadId`, but `createOfferOob` never returned it, so OOB offers silently reported an undefined parent thread id.

## Why correlation is not affected

- The exchange record still gets `parentThreadId` from the patch — that is what webhooks and the correlation bridge read.
- `credentialExchangeRecord.threadId` is a standalone uuid (`DidCommCredentialV2Protocol.createOffer`), and the format coordinator already binds the message to it via `setThread`. Re-setting the thread with that same id preserves the linkage, so the holder's request-credential still matches the record.
- The `DidCommMessageRecord` copy of the offer was saved by the coordinator *before* the patch mutated the message, so it never held the `pthid` anyway — the wire message now matches the stored one.

## Scope

- Connection-based `create-offer` / `offerCredential` path is untouched; its `pthid` behaviour is unchanged.
- No behaviour change when `parentThreadId` is absent.
- Only the OOB response gains a field; no field is removed or renamed.

## Verification

- `npx tsc --noEmit` — no new errors (remaining ones are pre-existing and confined to `__tests__`).
- `npx prettier --check` on the changed file — clean.
- No unit test added: this repo has no jest step in CI, and the defect is in wire-format assembly that only reproduces against a live holder.

### Manual test plan

1. Issue an OOB JSON-LD credential offer **with** a `parentThreadId` and scan the QR from a wallet that has **no** existing connection to the org → connection forms **and** the credential offer prompt appears.
2. Scan a freshly generated offer again from the same wallet (connection reuse path) → offer prompt appears, no generic error.
3. Confirm `credentialRequestParentThId` comes back on the OOB response and that `issueCredParentThreadId` is populated downstream.
4. Regression: issue over `connectionId` with a `parentThreadId` → unchanged, and the record's `parentThreadId` still matches.

Wallet log lines worth watching while testing: `Out of band invitation requests~attach message contains parent thread id` and `Promise waiting for the connection to be complete failed` should both be absent.

## Known adjacent issue (not in this PR)

On a **first** scan the attached offer is delivered only after DID Exchange completes, gated by `returnWhenIsConnected` with a hard 20 s default that `acceptInvitationFromUrl` never overrides. If the handshake through the mediator exceeds 20 s the offer is dropped with only a log line. That is a wallet-side fix (`acceptInvitationTimeoutMs`) and overlaps the ongoing mediator latency work.