### PR TITLE
[Eth] fix(ethereum): use jwt auth on EthereumController, matching PolygonController

### DIFF
--- a/src/controllers/ethereum/EthereumController.ts
+++ b/src/controllers/ethereum/EthereumController.ts
@@ -7,8 +7,9 @@ import * as fs from 'fs'
 import { Route, Tags, Security, Controller, Post, TsoaResponse, Res, Body, Get, Path } from 'tsoa'
 import { injectable } from 'tsyringe'
 
+import { SCOPES } from '../../enums'
+
 @Tags('Ethereum')
-@Security('apiKey')
 @Route('/ethereum')
 @injectable()
 export class Ethereum extends Controller {
@@ -24,6 +25,7 @@ export class Ethereum extends Controller {
    *
    * @returns Secp256k1KeyPair
    */
+  @Security('jwt', [SCOPES.TENANT_AGENT, SCOPES.DEDICATED_AGENT, SCOPES.MULTITENANT_BASE_AGENT])
   @Post('create-keys')
   public async createKeyPair(@Res() internalServerError: TsoaResponse<500, { message: string }>): Promise<{
     privateKey: string
@@ -43,6 +45,7 @@ export class Ethereum extends Controller {
    *
    * @returns Schema JSON
    */
+  @Security('jwt', [SCOPES.TENANT_AGENT, SCOPES.DEDICATED_AGENT])
   @Post('create-schema')
   public async createSchema(
     @Body()
@@ -93,6 +96,7 @@ export class Ethereum extends Controller {
    *
    * @returns Schema JSON
    */
+  @Security('jwt', [SCOPES.TENANT_AGENT, SCOPES.DEDICATED_AGENT])
   @Post('migrate-schema')
   public async migrateSchema(
     @Body()
@@ -147,6 +151,7 @@ export class Ethereum extends Controller {
    *
    * @returns Schema Object
    */
+  @Security('jwt', [SCOPES.TENANT_AGENT, SCOPES.DEDICATED_AGENT])
   @Get(':did/:schemaId')
   public async getSchemaById(
     @Path('did') did: string,

--- a/src/controllers/ethereum/EthereumController.ts
+++ b/src/controllers/ethereum/EthereumController.ts
@@ -156,7 +156,7 @@ export class Ethereum extends Controller {
     @Res() forbiddenError: TsoaResponse<401, { reason: string }>,
   ): Promise<unknown> {
     try {
-      return request.agent.modules.ethereum.getSchemaById(did, schemaId)
+      return await request.agent.modules.ethereum.getSchemaById(did, schemaId)
     } catch (error) {
       if (error instanceof CredoError) {
         if (error.message.includes('UnauthorizedClientRequest')) {

--- a/src/controllers/ethereum/EthereumController.ts
+++ b/src/controllers/ethereum/EthereumController.ts
@@ -1,10 +1,10 @@
-import type { RestAgentModules } from '../../cliAgent'
 import type { SchemaMetadata } from '../types'
 
 import { generateSecp256k1KeyPair } from '@ayanworks/credo-polygon-w3c-module'
-import { Agent, CredoError } from '@credo-ts/core'
+import { CredoError } from '@credo-ts/core'
+import { Request as Req } from 'express'
 import * as fs from 'fs'
-import { Route, Tags, Security, Controller, Post, TsoaResponse, Res, Body, Get, Path } from 'tsoa'
+import { Route, Tags, Security, Controller, Post, TsoaResponse, Res, Body, Get, Path, Request } from 'tsoa'
 import { injectable } from 'tsyringe'
 
 import { SCOPES } from '../../enums'
@@ -13,13 +13,6 @@ import { SCOPES } from '../../enums'
 @Route('/ethereum')
 @injectable()
 export class Ethereum extends Controller {
-  private agent: Agent<RestAgentModules>
-
-  public constructor(agent: Agent<RestAgentModules>) {
-    super()
-    this.agent = agent
-  }
-
   /**
    * Create Ethereum key pair for ethereum DID
    *
@@ -48,6 +41,7 @@ export class Ethereum extends Controller {
   @Security('jwt', [SCOPES.TENANT_AGENT, SCOPES.DEDICATED_AGENT])
   @Post('create-schema')
   public async createSchema(
+    @Request() request: Req,
     @Body()
     createSchemaRequest: {
       did: string
@@ -65,7 +59,7 @@ export class Ethereum extends Controller {
         })
       }
 
-      const schemaResponse = await this.agent.modules.ethereum.createSchema({
+      const schemaResponse = await request.agent.modules.ethereum.createSchema({
         did,
         schemaName,
         schema,
@@ -99,6 +93,7 @@ export class Ethereum extends Controller {
   @Security('jwt', [SCOPES.TENANT_AGENT, SCOPES.DEDICATED_AGENT])
   @Post('migrate-schema')
   public async migrateSchema(
+    @Request() request: Req,
     @Body()
     migrateSchemaRequest: {
       did: string
@@ -121,7 +116,7 @@ export class Ethereum extends Controller {
         })
       }
 
-      const schemaResponse = await this.agent.modules.ethereum.createExistingSchema({
+      const schemaResponse = await request.agent.modules.ethereum.createExistingSchema({
         did,
         schemaId,
       })
@@ -154,13 +149,14 @@ export class Ethereum extends Controller {
   @Security('jwt', [SCOPES.TENANT_AGENT, SCOPES.DEDICATED_AGENT])
   @Get(':did/:schemaId')
   public async getSchemaById(
+    @Request() request: Req,
     @Path('did') did: string,
     @Path('schemaId') schemaId: string,
     @Res() internalServerError: TsoaResponse<500, { message: string }>,
     @Res() forbiddenError: TsoaResponse<401, { reason: string }>,
   ): Promise<unknown> {
     try {
-      return this.agent.modules.ethereum.getSchemaById(did, schemaId)
+      return request.agent.modules.ethereum.getSchemaById(did, schemaId)
     } catch (error) {
       if (error instanceof CredoError) {
         if (error.message.includes('UnauthorizedClientRequest')) {

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -5718,7 +5718,7 @@ export function RegisterRoutes(app: Router) {
                 internalServerError: {"in":"res","name":"500","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"message":{"dataType":"string","required":true}}},
         };
         app.post('/ethereum/create-keys',
-            authenticateMiddleware([{"apiKey":[]}]),
+            authenticateMiddleware([{"jwt":["tenant","dedicated","Basewallet"]}]),
             ...(fetchMiddlewares<RequestHandler>(Ethereum)),
             ...(fetchMiddlewares<RequestHandler>(Ethereum.prototype.createKeyPair)),
 
@@ -5756,7 +5756,7 @@ export function RegisterRoutes(app: Router) {
                 badRequestError: {"in":"res","name":"400","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"reason":{"dataType":"string","required":true}}},
         };
         app.post('/ethereum/create-schema',
-            authenticateMiddleware([{"apiKey":[]}]),
+            authenticateMiddleware([{"jwt":["tenant","dedicated"]}]),
             ...(fetchMiddlewares<RequestHandler>(Ethereum)),
             ...(fetchMiddlewares<RequestHandler>(Ethereum.prototype.createSchema)),
 
@@ -5794,7 +5794,7 @@ export function RegisterRoutes(app: Router) {
                 badRequestError: {"in":"res","name":"400","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"reason":{"dataType":"string","required":true}}},
         };
         app.post('/ethereum/migrate-schema',
-            authenticateMiddleware([{"apiKey":[]}]),
+            authenticateMiddleware([{"jwt":["tenant","dedicated"]}]),
             ...(fetchMiddlewares<RequestHandler>(Ethereum)),
             ...(fetchMiddlewares<RequestHandler>(Ethereum.prototype.migrateSchema)),
 
@@ -5833,7 +5833,7 @@ export function RegisterRoutes(app: Router) {
                 forbiddenError: {"in":"res","name":"401","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"reason":{"dataType":"string","required":true}}},
         };
         app.get('/ethereum/:did/:schemaId',
-            authenticateMiddleware([{"apiKey":[]}]),
+            authenticateMiddleware([{"jwt":["tenant","dedicated"]}]),
             ...(fetchMiddlewares<RequestHandler>(Ethereum)),
             ...(fetchMiddlewares<RequestHandler>(Ethereum.prototype.getSchemaById)),
 

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -5751,6 +5751,7 @@ export function RegisterRoutes(app: Router) {
         });
         // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
         const argsEthereum_createSchema: Record<string, TsoaRoute.ParameterSchema> = {
+                request: {"in":"request","name":"request","required":true,"dataType":"object"},
                 createSchemaRequest: {"in":"body","name":"createSchemaRequest","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"schema":{"dataType":"nestedObjectLiteral","nestedProperties":{},"additionalProperties":{"dataType":"any"},"required":true},"schemaName":{"dataType":"string","required":true},"did":{"dataType":"string","required":true}}},
                 internalServerError: {"in":"res","name":"500","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"message":{"dataType":"string","required":true}}},
                 badRequestError: {"in":"res","name":"400","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"reason":{"dataType":"string","required":true}}},
@@ -5789,6 +5790,7 @@ export function RegisterRoutes(app: Router) {
         });
         // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
         const argsEthereum_migrateSchema: Record<string, TsoaRoute.ParameterSchema> = {
+                request: {"in":"request","name":"request","required":true,"dataType":"object"},
                 migrateSchemaRequest: {"in":"body","name":"migrateSchemaRequest","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"schemaId":{"dataType":"string","required":true},"did":{"dataType":"string","required":true}}},
                 internalServerError: {"in":"res","name":"500","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"message":{"dataType":"string","required":true}}},
                 badRequestError: {"in":"res","name":"400","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"reason":{"dataType":"string","required":true}}},
@@ -5827,6 +5829,7 @@ export function RegisterRoutes(app: Router) {
         });
         // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
         const argsEthereum_getSchemaById: Record<string, TsoaRoute.ParameterSchema> = {
+                request: {"in":"request","name":"request","required":true,"dataType":"object"},
                 did: {"in":"path","name":"did","required":true,"dataType":"string"},
                 schemaId: {"in":"path","name":"schemaId","required":true,"dataType":"string"},
                 internalServerError: {"in":"res","name":"500","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"message":{"dataType":"string","required":true}}},

--- a/src/routes/swagger.json
+++ b/src/routes/swagger.json
@@ -9918,6 +9918,9 @@
 										"invitationDid": {
 											"type": "string"
 										},
+										"credentialRequestParentThId": {
+											"type": "string"
+										},
 										"credentialRequestThId": {
 											"type": "string"
 										},
@@ -9939,6 +9942,7 @@
 									},
 									"required": [
 										"invitationDid",
+										"credentialRequestParentThId",
 										"credentialRequestThId",
 										"credentialExchangeRecordId",
 										"outOfBandRecordId",
@@ -10783,7 +10787,11 @@
 				],
 				"security": [
 					{
-						"apiKey": []
+						"jwt": [
+							"tenant",
+							"dedicated",
+							"Basewallet"
+						]
 					}
 				],
 				"parameters": []
@@ -10844,7 +10852,10 @@
 				],
 				"security": [
 					{
-						"apiKey": []
+						"jwt": [
+							"tenant",
+							"dedicated"
+						]
 					}
 				],
 				"parameters": [],
@@ -10933,7 +10944,10 @@
 				],
 				"security": [
 					{
-						"apiKey": []
+						"jwt": [
+							"tenant",
+							"dedicated"
+						]
 					}
 				],
 				"parameters": [],
@@ -11016,7 +11030,10 @@
 				],
 				"security": [
 					{
-						"apiKey": []
+						"jwt": [
+							"tenant",
+							"dedicated"
+						]
 					}
 				],
 				"parameters": [


### PR DESCRIPTION
## Summary

`EthereumController`'s routes (`create-keys`, `create-schema`, `migrate-schema`,
`getSchemaById`) all inherited a class-level `@Security('apiKey')`, which checks the
incoming `authorization` header against the server's own static `dynamicApiKey`.

Platform's `agent-service` doesn't send that static key for these calls — for every
agent-controller call, Polygon and Ethereum alike, it fetches the platform-admin org's
agent record, decrypts its stored token, and sends that as `authorization`. That
decrypted token is a **JWT** (the agent's own auth token), not the server's static API
key.

`PolygonController` already accounts for this — each of its methods carries its own
`@Security('jwt', [SCOPES...])` decorator. `EthereumController` never got the equivalent
treatment, so its `apiKey` check compares the JWT against an unrelated static value and
always fails with 401.

## Why this wasn't caught during the port

`pipeline-implementation` (the source branch did:ethr was ported from) has the identical
class-level `@Security('apiKey')` on *both* `PolygonController` and `EthereumController`
— internally consistent there, since that branch's whole auth convention predates the
JWT/scopes-based auth model. Polygon's auth was modernized to JWT/scopes later, as part
of general v2.2.0 work unrelated to Ethereum. The did:ethr port (#64) faithfully carried
over `pipeline-implementation`'s original `apiKey` scheme, which was correct for its
source branch but had already gone stale relative to `develop`'s current Polygon
convention it should have mirrored instead.

## Fix

Replaced the class-level `@Security('apiKey')` with per-method `@Security('jwt', [...])`
decorators, mirroring `PolygonController`'s exact scopes:
- `create-keys`: `[TENANT_AGENT, DEDICATED_AGENT, MULTITENANT_BASE_AGENT]`
- `create-schema` / `migrate-schema` / `getSchemaById`: `[TENANT_AGENT, DEDICATED_AGENT]`

Regenerated `routes.ts`/`swagger.json` via `yarn tsoa` to match.

## Verification

- Reproduced against a live deploy: `POST /orgs/:orgId/agents/ethereum/create-keys`
  401'd with the exact `apiKey`-vs-JWT mismatch described above, while the identical
  call pattern for Polygon's `create-keys` succeeded — confirmed the two controllers'
  security decorators diverge exactly as described.
- `yarn check-types` / `yarn check-types:test`: clean.
- `yarn lint`: 0 errors.
- `yarn test`: 110/110 passing.
- Confirmed the regenerated spec shows `jwt` security with the correct scopes on all
  four Ethereum routes.