### PR TITLE
chore(deps): update @bhutan-ndi/ethr-credo-module to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@ayanworks/credo-polygon-w3c-module": "2.0.2",
-    "@bhutan-ndi/ethr-credo-module": "1.0.3",
+    "@bhutan-ndi/ethr-credo-module": "2.0.0",
     "@digitalcredentials/jsonld": "^9.0.0",
     "@sd-jwt/jwt-status-list": "0.19.0",
     "@credo-ts/anoncreds": "0.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -389,18 +389,16 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bhutan-ndi/ethr-credo-module@1.0.3":
-  version "1.0.3"
-  resolved "https://registry.npmjs.org/@bhutan-ndi/ethr-credo-module/-/ethr-credo-module-1.0.3.tgz#68446d4db54488f20228292e7cfd07eabad53d61"
-  integrity sha512-/COABV+ltk0Vab4VXwJoJulgeO61Y83S44kzl9zsFme++BulzPKA9pWi+YX17zuXtvwuLoR/W6PiyBTEMwlyDg==
+"@bhutan-ndi/ethr-credo-module@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@bhutan-ndi/ethr-credo-module/-/ethr-credo-module-2.0.0.tgz#d5e7ece03e62e7ccffe1fc8f51dc64ebc17dcd61"
+  integrity sha512-AUE2TeuFaDlRkXr+EdhSxndP1Scf1+kk5Dc7LeZyUsG43UtucU00ZkAScs0GFdAjh9wBYItS/+UxWv7yi5GSOA==
   dependencies:
-    "@credo-ts/askar" "0.5.3"
-    "@credo-ts/core" "0.5.3"
     axios "^1.6.3"
     did-resolver "^4.1.0"
     ethers "^6.9.0"
     ethr-did "^3.0.38"
-    ethr-did-resolver "^11.0.4"
+    ethr-did-resolver "~11.0.4"
     keccak256 "^1.0.6"
 
 "@credo-ts/anoncreds@0.6.2":
@@ -416,7 +414,7 @@
     class-validator "^0.14.3"
     reflect-metadata "0.2.2"
 
-"@credo-ts/askar@0.5.3", "@credo-ts/askar@0.6.2", "@credo-ts/askar@^0.6.1":
+"@credo-ts/askar@0.6.2", "@credo-ts/askar@^0.6.1":
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/@credo-ts/askar/-/askar-0.6.2.tgz#3d5ea35e9a30f41df9db0134bae1d185aa8e5fda"
   integrity sha512-SeAjHBuk+2l5For/0v8vzQuDbBB6TbLRg8AfChKV2phGsKKoIGXtDwZZLicvB+bgtRrR221keL8LrHp9kN3o7Q==
@@ -427,7 +425,7 @@
     rxjs "^7.8.2"
     tsyringe "^4.10.0"
 
-"@credo-ts/core@0.5.3", "@credo-ts/core@0.6.2", "@credo-ts/core@^0.6.1":
+"@credo-ts/core@0.6.2", "@credo-ts/core@^0.6.1":
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/@credo-ts/core/-/core-0.6.2.tgz#7ee8e78ce3fad3d2c60db978623e2b29784b24b7"
   integrity sha512-A7yXs6y/73wIvgEHpfriVZW1osuASYhrO/TQIFlwSK/cRTjaXWFgBapzYaJh09O1PuEJ4v1A1mt72uardqCj8g==
@@ -4117,11 +4115,6 @@ did-resolver@^4.1.0:
   resolved "https://registry.yarnpkg.com/did-resolver/-/did-resolver-4.1.0.tgz#740852083c4fd5bf9729d528eca5d105aff45eb6"
   integrity sha512-S6fWHvCXkZg2IhS4RcVHxwuyVejPR7c+a4Go0xbQ9ps5kILa8viiYQgrM4gfTyeTjJ0ekgJH9gk/BawTpmkbZA==
 
-did-resolver@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.npmjs.org/did-resolver/-/did-resolver-5.0.1.tgz#5d6775b236b64124341471807d84058c76ff64db"
-  integrity sha512-AtbIfBt/D9Z6GeNKhm1AzCbF7y5PhsNukgmVYnsdxbIX8UAsquQpbm8ECfPwDRXAOM3EsGdHheK5WMojcPlAPg==
-
 diff-sequences@^29.6.3:
   version "29.6.3"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.6.3.tgz#4deaf894d11407c51efc8418012f9e70b84ea921"
@@ -4631,12 +4624,12 @@ ethr-did-resolver@11.0.4:
     did-resolver "^4.1.0"
     ethers "^6.8.1"
 
-ethr-did-resolver@^11.0.4:
-  version "11.1.3"
-  resolved "https://registry.npmjs.org/ethr-did-resolver/-/ethr-did-resolver-11.1.3.tgz#9adc856f2596492735c7ac996f9aeb7bfd6f5449"
-  integrity sha512-YKZYazilgH9ikcEJN5WTIWhY/3G45SSoBbhwJkzb3m9QjG2pBjAg2aYLSRYgK463zAu2EuNvUjMmZ8vsk2EbiQ==
+ethr-did-resolver@~11.0.4:
+  version "11.0.5"
+  resolved "https://registry.yarnpkg.com/ethr-did-resolver/-/ethr-did-resolver-11.0.5.tgz#24cc01cbdb6c878c26d83be5d8a140488f680611"
+  integrity sha512-fTQ+4g4aRDyU1hzlPH6FYgpoOd7fM8ZV9+3JCl2PqSDnS8Iz9V+y/9KOjLzqhY6LKhMWW5hIbaGypwOPWj15JA==
   dependencies:
-    did-resolver "^5.0.0"
+    did-resolver "^4.1.0"
     ethers "^6.8.1"
 
 ethr-did@^3.0.38:


### PR DESCRIPTION
## Summary
- Bump `@bhutan-ndi/ethr-credo-module` from `1.0.3` to the stable `2.0.0` release, which fixes the credo version incompatibility between the library and this controller.
- Previously validated on an alpha pre-release of `2.0.0`; this swaps in the published stable version.

## Notes
- `@bhutan-ndi/ethr-credo-module@2.0.0` declares peer dependencies on `@credo-ts/core@^0.6.3` and `@credo-ts/askar@^0.6.3`, while this repo currently pins those at `0.6.2`. Yarn emits a non-fatal "incorrect peer dependency" warning as a result; bumping the `@credo-ts/*` family itself is out of scope for this PR.

## Test plan
- [x] `yarn install` resolves cleanly (only expected peer-dependency warning noted above)
- [x] `yarn check-types` passes
- [x] `yarn compile` builds successfully
- [ ] Manual smoke test of did:ethr flows against this build