### PR TITLE
 [Cloud Wallet] agent-controller: port checkCloudWalletExists endpoint

### DIFF
--- a/src/controllers/multi-tenancy/MultiTenancyController.ts
+++ b/src/controllers/multi-tenancy/MultiTenancyController.ts
@@ -121,6 +121,26 @@ export class MultiTenancyController extends Controller {
     }
   }
 
+  /**
+   * Check whether a tenant exists — ported from pipeline-implementation, adapted to use
+   * request.agent (the current develop convention) instead of the legacy this.agent field,
+   * which no longer exists on this controller.
+   */
+  @Get('/checkCloudWalletExists/:tenantId')
+  public async getCloudWallet(@Request() request: Req, @Path('tenantId') tenantId: string) {
+    try {
+      const agent = request.agent as Agent<RestMultiTenantAgentModules>
+      const tenant = await agent.modules.tenants.getTenantById(tenantId)
+      if (tenant) {
+        return 'Tenant exists'
+      }
+      this.setStatus(404)
+      return 'Tenant does not exist'
+    } catch (error) {
+      throw ErrorHandlingService.handle(error)
+    }
+  }
+
   private async createToken(agent: Agent<RestMultiTenantAgentModules>, tenantId: string, secretKey?: string) {
     let key: string
     if (!secretKey) {

--- a/src/controllers/multi-tenancy/__tests__/MultiTenancyController.checkCloudWalletExists.spec.ts
+++ b/src/controllers/multi-tenancy/__tests__/MultiTenancyController.checkCloudWalletExists.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * Regression tests for MultiTenancyController.getCloudWallet — ported from
+ * pipeline-implementation's checkCloudWalletExists endpoint.
+ *
+ * Locks in the one real change from the legacy version: it must resolve the agent from
+ * request.agent (the current develop convention, used by every other method on this
+ * controller), not the legacy this.agent field, which no longer exists on this class.
+ *
+ * Runs under Jest's ESM mode (see jest.config.base.ts) — tsyringe is mocked so constructing
+ * the controller does not require a real DI container.
+ */
+import { jest } from '@jest/globals'
+
+const noopDecorator = () => () => {}
+
+jest.unstable_mockModule('tsyringe', () => ({
+  injectable: noopDecorator,
+  singleton: noopDecorator,
+  scoped: noopDecorator,
+  autoInjectable: noopDecorator,
+  inject: noopDecorator,
+  injectAll: noopDecorator,
+  delay: (fn: unknown) => fn,
+  Lifecycle: { Singleton: 0, Transient: 1, ResolutionScoped: 2, ContainerScoped: 3 },
+  container: {
+    resolve: jest.fn(() => ({})),
+    register: jest.fn(),
+    registerInstance: jest.fn(),
+    isRegistered: jest.fn(() => false),
+  },
+}))
+
+const { MultiTenancyController } = await import('../MultiTenancyController')
+
+type MockAgent = { modules: { tenants: { getTenantById: jest.Mock } } }
+
+const makeAgent = (getTenantByIdImpl: jest.Mock): MockAgent => ({
+  modules: { tenants: { getTenantById: getTenantByIdImpl } },
+})
+
+const makeRequest = (agent: MockAgent) => ({ agent }) as never
+
+describe('MultiTenancyController.getCloudWallet', () => {
+  it('uses request.agent, not a this.agent field, to look up the tenant', async () => {
+    const getTenantById = jest.fn(async () => ({ id: 'tenant-1' })) as jest.Mock
+    const agent = makeAgent(getTenantById)
+    const controller = new MultiTenancyController()
+
+    const result = await controller.getCloudWallet(makeRequest(agent), 'tenant-1')
+
+    expect(getTenantById).toHaveBeenCalledWith('tenant-1')
+    expect(result).toBe('Tenant exists')
+  })
+
+  it('returns 404 "Tenant does not exist" when the tenant is not found (falsy, not thrown)', async () => {
+    const getTenantById = jest.fn(async () => undefined) as jest.Mock
+    const agent = makeAgent(getTenantById)
+    const controller = new MultiTenancyController()
+    const setStatusSpy = jest.spyOn(controller, 'setStatus')
+
+    const result = await controller.getCloudWallet(makeRequest(agent), 'missing-tenant')
+
+    expect(result).toBe('Tenant does not exist')
+    expect(setStatusSpy).toHaveBeenCalledWith(404)
+  })
+
+  it('propagates a RecordNotFoundError through ErrorHandlingService (converted to NotFoundError)', async () => {
+    const { RecordNotFoundError } = await import('@credo-ts/core')
+    const { NotFoundError } = await import('../../../errors')
+    const getTenantById = jest.fn(async () => {
+      throw new RecordNotFoundError('not found', { recordType: 'TenantRecord' })
+    }) as jest.Mock
+    const agent = makeAgent(getTenantById)
+    const controller = new MultiTenancyController()
+
+    await expect(controller.getCloudWallet(makeRequest(agent), 'missing-tenant')).rejects.toThrow(NotFoundError)
+  })
+})

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -3816,6 +3816,43 @@ export function RegisterRoutes(app: Router) {
             }
         });
         // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsMultiTenancyController_getCloudWallet: Record<string, TsoaRoute.ParameterSchema> = {
+                request: {"in":"request","name":"request","required":true,"dataType":"object"},
+                tenantId: {"in":"path","name":"tenantId","required":true,"dataType":"string"},
+        };
+        app.get('/multi-tenancy/checkCloudWalletExists/:tenantId',
+            authenticateMiddleware([{"jwt":["Basewallet"]}]),
+            ...(fetchMiddlewares<RequestHandler>(MultiTenancyController)),
+            ...(fetchMiddlewares<RequestHandler>(MultiTenancyController.prototype.getCloudWallet)),
+
+            async function MultiTenancyController_getCloudWallet(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsMultiTenancyController_getCloudWallet, request, response });
+
+                const container: IocContainer = typeof iocContainer === 'function' ? (iocContainer as IocContainerFactory)(request) : iocContainer;
+
+                const controller: any = await container.get<MultiTenancyController>(MultiTenancyController);
+                if (typeof controller['setStatus'] === 'function') {
+                controller.setStatus(undefined);
+                }
+
+              await templateService.apiHandler({
+                methodName: 'getCloudWallet',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
         const argsQuestionAnswerController_getQuestionAnswerRecords: Record<string, TsoaRoute.ParameterSchema> = {
                 request: {"in":"request","name":"request","required":true,"dataType":"object"},
                 connectionId: {"in":"query","name":"connectionId","dataType":"string"},

--- a/src/routes/swagger.json
+++ b/src/routes/swagger.json
@@ -7456,6 +7456,48 @@
 				]
 			}
 		},
+		"/multi-tenancy/checkCloudWalletExists/{tenantId}": {
+			"get": {
+				"operationId": "GetCloudWallet",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "string",
+									"enum": [
+										"Tenant exists",
+										"Tenant does not exist"
+									]
+								}
+							}
+						}
+					}
+				},
+				"description": "Check whether a tenant exists — ported from pipeline-implementation, adapted to use\nrequest.agent (the current develop convention) instead of the legacy this.agent field,\nwhich no longer exists on this controller.",
+				"tags": [
+					"MultiTenancy"
+				],
+				"security": [
+					{
+						"jwt": [
+							"Basewallet"
+						]
+					}
+				],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "tenantId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
 		"/didcomm/question-answer": {
 			"get": {
 				"operationId": "GetQuestionAnswerRecords",


### PR DESCRIPTION
## What
`GET /multi-tenancy/checkCloudWalletExists/:tenantId` — backs platform's `CLOUD_WALLET_CHECK_CLOUD_WALLET_EXISTS` HTTP constant. Ported from `pipeline-implementation`.

## Change from the legacy version
The legacy code used `this.agent.modules.tenants.getTenantById(tenantId)` — but `MultiTenancyController` no longer has a `this.agent` field on `develop`; every other method already uses `request.agent`. Adapted for consistency with the rest of this controller.

## Verification
- `yarn validate`: clean
- `yarn test`: 113/113 (3 new specs — `request.agent` usage, the 404 falsy-tenant path, and `RecordNotFoundError` → proper 404 via `ErrorHandlingService`)
- `yarn build`: clean